### PR TITLE
improve management of sub-aoi

### DIFF
--- a/component/parameter/viz_params.py
+++ b/component/parameter/viz_params.py
@@ -29,9 +29,9 @@ plt_viz = {
 aoi_style = {  # default styling of the layer
     "stroke": True,
     "color": "black",
-    "weight": 2,
+    "weight": 1,
     "opacity": 1,
     "fill": True,
     "fillColor": "black",
-    "fillOpacity": 0.4,
+    "fillOpacity": 0.05,
 }

--- a/component/tile/map_tile.py
+++ b/component/tile/map_tile.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+from copy import deepcopy
 
 from sepal_ui import sepalwidgets as sw
 from sepal_ui import mapping as sm
@@ -21,6 +22,9 @@ from component import widget as cw
 
 
 class MapTile(sw.Tile):
+
+    EMPTY_FEATURES = {"type": "FeatureCollection", "features": []}
+
     def __init__(self, questionnaire_tile, aoi_model, area_tile, theme_tile):
 
         # add the explanation
@@ -35,7 +39,7 @@ class MapTile(sw.Tile):
         self.m.add_colorbar(colors=cp.red_to_green, vmin=1, vmax=5)
 
         # drawing managment
-        self.draw_features = {"type": "FeatureCollection", "features": []}
+        self.draw_features = deepcopy(self.EMPTY_FEATURES)
         self.colors = []
         self.name_dialog = cw.CustomAoiDialog()
 
@@ -122,6 +126,8 @@ class MapTile(sw.Tile):
             for l in self.m.layers
             if l.name not in ["CartoDB.DarkMatter"]
         ]
+        self.m.dc.clear()
+        self.draw_features = deepcopy(self.EMPTY_FEATURES)
 
         # create a layer and a dashboard
         self.wlc_outputs = cs.wlc(

--- a/component/tile/map_tile.py
+++ b/component/tile/map_tile.py
@@ -116,6 +116,11 @@ class MapTile(sw.Tile):
     def _compute(self, widget, data, event):
         """compute the restoration plan and display the map"""
 
+        # remove the previous sub aoi from the map
+        for l in self.m.layers:
+            if l.name not in ["CartoDB.DarkMatter"]:
+                self.m.remove_layer(l)
+
         # create a layer and a dashboard
         self.wlc_outputs = cs.wlc(
             self.layer_model.layer_list,

--- a/component/tile/map_tile.py
+++ b/component/tile/map_tile.py
@@ -117,9 +117,11 @@ class MapTile(sw.Tile):
         """compute the restoration plan and display the map"""
 
         # remove the previous sub aoi from the map
-        for l in self.m.layers:
-            if l.name not in ["CartoDB.DarkMatter"]:
-                self.m.remove_layer(l)
+        [
+            self.m.remove_layer(l)
+            for l in self.m.layers
+            if l.name not in ["CartoDB.DarkMatter"]
+        ]
 
         # create a layer and a dashboard
         self.wlc_outputs = cs.wlc(
@@ -151,17 +153,26 @@ class MapTile(sw.Tile):
         """save the features as layers on the map"""
 
         # remove any sub aoi layer
-        [self.m.remove_layer(l) for l in self.m.layers if "sub aoi" in l.name]
+        layers_2_keep = ["CartoDB.DarkMatter", "restoration layer"]
+        [self.m.remove_layer(l) for l in self.m.layers if l.name not in layers_2_keep]
 
         # save the drawn features
         draw_features = self.draw_features
 
         # remove the shapes from the dc
-        # as a side effect the draw_feature member will be emptied
+        # as a side effect the draw_features member will be emptied
         self.m.dc.clear()
 
         # reset the draw_features
+        # I'm sure the the AOI folder exists because the recipe was already saved there
         self.draw_features = draw_features
+        features_file = (
+            cp.result_dir
+            / self.aoi_model.name
+            / f"features_{self.question_model.recipe_name}.geojson"
+        )
+        with features_file.open("w") as f:
+            json.dump(draw_features, f)
 
         # set up the colors using the tab10 matplotlib colormap
         self.colors = [

--- a/component/tile/map_tile.py
+++ b/component/tile/map_tile.py
@@ -116,6 +116,18 @@ class MapTile(sw.Tile):
             }
             self._add_geom(feat, row[column])
 
+        # display a tmp geometry before validation
+        data = json.loads(gdf.to_json())
+        style = {
+            **cp.aoi_style,
+            "color": sc.info,
+            "fillColor": sc.info,
+            "opacity": 0.5,
+            "weight": 2,
+        }
+        layer = GeoJSON(data=data, style=style, name="tmp")
+        self.m.add_layer(layer)
+
         return
 
     def _add_geom(self, geo_json, name):

--- a/no_ui.ipynb
+++ b/no_ui.ipynb
@@ -90,7 +90,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rp_map_tile.m.layers"
+    "len(rp_map_tile.m.layers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(rp_map_tile.draw_features[\"features\"])"
    ]
   },
   {

--- a/no_ui.ipynb
+++ b/no_ui.ipynb
@@ -98,6 +98,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "rp_map_tile.draw_features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/no_ui.ipynb
+++ b/no_ui.ipynb
@@ -89,6 +89,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "rp_map_tile.m.layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/no_ui.ipynb
+++ b/no_ui.ipynb
@@ -89,33 +89,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "len(rp_map_tile.m.layers)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(rp_map_tile.draw_features[\"features\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rp_map_tile.draw_features"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],


### PR DESCRIPTION
- empty the map when reloading the recipe (act like a reset btn for sub aoi) Fix #80 
- display a preview when a geojson is loaded before it's validated
- display the name of the aoi when geometry is hovered on the map 
- display the main AOI (using the color of the dashboard but without fillcolor) 
- export the geometries a .geojson file