### PR TITLE
fix: clear stale w_id when user types a custom name in layer dialogs

### DIFF
--- a/component/widget/benefit_dialog.py
+++ b/component/widget/benefit_dialog.py
@@ -182,6 +182,8 @@ class BenefitDialog(BaseDialog):
             return
 
         if self.w_name.v_model not in self.w_name.items:
+            if self.w_id.v_model in self._BENEFITS.layer_id.tolist():
+                self.w_id.v_model = None
             return
 
         # get the information from the dataframe

--- a/component/widget/constraint_dialog.py
+++ b/component/widget/constraint_dialog.py
@@ -208,6 +208,8 @@ class ConstraintDialog(BaseDialog):
             return
 
         if self.w_name.v_model not in self.w_name.items:
+            if self.w_id.v_model in self._CONSTRAINTS.layer_id.tolist():
+                self.w_id.v_model = None
             return
 
         # get the information from the dataframe

--- a/component/widget/cost_dialog.py
+++ b/component/widget/cost_dialog.py
@@ -167,6 +167,8 @@ class CostDialog(BaseDialog):
             return
 
         if self.w_name.v_model not in self.w_name.items:
+            if self.w_id.v_model in self._COSTS.layer_id.tolist():
+                self.w_id.v_model = None
             return
 
         # get the information from the dataframe


### PR DESCRIPTION
## Summary

Fixes a bug where typing a custom name in the constraint/benefit/cost dialog after selecting a subtheme could silently **overwrite an existing default layer** instead of adding a new custom one — making the previous layer appear to "disappear" from the table.

## Root cause

When the user opens \"New constraint\" and picks a subtheme, `theme_change` auto-fills `w_name` with the first layer of that subtheme, which triggers `name_change` and sets `w_id` to that layer's id (e.g. `city_access`). If the user then types a **custom name** (not in `w_name.items`), `name_change` returned early without touching `w_id`, leaving it pointing at the default layer. On `validate`, `self.w_id.v_model in self.model.ids` was True, so the dialog called `model.update(**kwargs)` instead of `model.add(...)`, replacing the existing default layer's metadata (name, asset, unit, data_type) with the user's custom data.

Same pattern existed in `BenefitDialog` and `CostDialog`.

## Fix

In `name_change`, when the typed name is not a preset AND `w_id` currently points to a default layer id (from the CSV), clear `w_id` so `validate()` generates a fresh `custom_*_N` id and calls `model.add()`. Custom ids (`custom_constraint_N` / `custom_benefit_N` / `custom_cost_N`) are preserved so editing an existing custom layer still calls `update()`.

## Test plan

- [x] Reproduced the bug without UI by simulating the dialog flow: added 6 unique `socio_eco` constraints, then typed a custom name after selecting `socio_eco` again — `city_access` got overwritten.
- [x] Verified the fix: with the patch, the same flow now adds the custom as an 8th entry and leaves `city_access` intact.
- [ ] Manual UI test in the app: add several defaults, then create a custom constraint (type a new name) and confirm the default layers remain unchanged.
- [ ] Edit an existing custom constraint and rename it — confirm it still updates in place (doesn't duplicate).