### PR TITLE
feat: Geoman map drawing, recipe header, CSV export, AOI gating

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           activate-environment: seplan
           auto-activate-base: false
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 USER $MAMBA_USER
 
 COPY requirements.txt /home/$MAMBA_USER/requirements.txt
-RUN micromamba create -n seplan python=3.10 pip -c conda-forge -y && \
+RUN micromamba create -n seplan python=3.12 pip -c conda-forge -y && \
     micromamba run -n seplan pip install -r /home/$MAMBA_USER/requirements.txt --no-cache-dir && \
     micromamba clean --all --yes && \
     rm -f /home/$MAMBA_USER/requirements.txt && \

--- a/component/model/aoi_model.py
+++ b/component/model/aoi_model.py
@@ -13,7 +13,7 @@ from sepal_ui.aoi.aoi_model import AoiModel
 from sepal_ui.message import ms
 from sepal_ui.scripts import utils as su
 from sepal_ui.scripts.gee_interface import GEEInterface
-from traitlets import Dict, Int, Any
+from traitlets import Bool, Dict, Int, Any
 
 import component.parameter as cp
 
@@ -176,6 +176,29 @@ class AoiModel(AoiModel):
 
         # set the default
         self.set_default(self.default_vector, self.default_admin, self.default_asset)
+
+    def _from_geo_json(self, geo_json: dict):
+        """Build the in-memory feature_collection from a drawn geometry.
+
+        Overrides pysepal's implementation to skip ``export_to_asset()`` —
+        for SE.PLAN we only need an ``ee.FeatureCollection`` in memory; we
+        don't want to persist user-drawn AOIs to their EE asset folder
+        (and pysepal's folder resolution falls through to the literal
+        string "None" when no folder is configured, breaking the export).
+        """
+        if not geo_json or not geo_json.get("features"):
+            raise Exception(ms.aoi_sel.exception.no_draw)
+
+        # Strip styling so geopandas/EE accept the geometry.
+        for feat in geo_json["features"]:
+            if "style" in feat.get("properties", {}):
+                del feat["properties"]["style"]
+
+        self.gdf = gpd.GeoDataFrame.from_features(geo_json).set_crs(epsg=4326)
+        self.name = su.normalize_str(self.name)
+        self.feature_collection = su.geojson_to_ee(self.gdf.__geo_interface__)
+
+        return self
 
     def set_object(self, method: str = ""):
         """Set the object (gdf/featurecollection) based on the model inputs.
@@ -390,6 +413,18 @@ class SeplanAoi(model.Model):
     updated = Int(0).tag(sync=True)
     """int: this trait will be updated every time the aoi_model is updated"""
 
+    aoi_lmic_valid = Bool(True).tag(sync=True)
+    """bool: True when the current AOI overlaps the LMIC mask. Defaults True
+    so a fresh app (no AOI yet) doesn't disable the right-panel actions
+    pre-emptively. Updated by ``custom_aoi_tile.AoiView._check_lmic`` after
+    each AOI change."""
+
+    aoi_lmic_checked = Int(0).tag(sync=True)
+    """int: counter that increments every time the LMIC verdict is settled
+    (sync admin path or async GEE path). Used by the AOI view to gate the
+    auto-close of the step dialog so the user can see a non-LMIC warning
+    before the dialog disappears."""
+
     def __init__(self, gee_interface=None, **kwargs):
         # test_countries:
         # Multiple polygon country: 220
@@ -397,11 +432,40 @@ class SeplanAoi(model.Model):
         # Medium department: 935 (Antioquia)
         self.aoi_model = AoiModel(gee_interface=gee_interface, **kwargs)
 
+        # Tracks the (method, name) of the primary AOI between updates so we
+        # can detect when the user replaces it (e.g. Colombia → Brazil) and
+        # drop sub-AOIs that referenced the previous primary.
+        self._prev_primary_id = None
+
+        # Suppresses the auto-clear in ``on_aoi_change`` while
+        # ``import_data``/``import_data_async`` is restoring a recipe — the
+        # recipe sets ``custom_layers`` before ``set_object`` fires ``updated``,
+        # so without this flag the just-restored sub-AOIs would be wiped.
+        self._loading = False
+
         self.aoi_model.observe(self.on_aoi_change, "updated")
 
     def on_aoi_change(self, change):
-        """Update the feature_collection when the aoi_model.name is updated."""
+        """Update the feature_collection when the aoi_model.name is updated.
+
+        Also clears ``custom_layers`` whenever the primary AOI identity
+        actually changes — sub-AOIs are defined relative to a primary, so
+        they're meaningless once that primary is replaced. Skipped during
+        recipe import (``_loading``) and on first set (``_prev_primary_id is
+        None``).
+        """
         self.feature_collection = self.aoi_model.feature_collection
+
+        new_id = (self.aoi_model.method, self.aoi_model.name)
+        identity_changed = (
+            self._prev_primary_id is not None and new_id != self._prev_primary_id
+        )
+        # Update prev *before* the clear so re-entrancy from the
+        # custom_layers/link → observer chain sees the new identity.
+        self._prev_primary_id = new_id
+        if identity_changed and not self._loading:
+            self.custom_layers = {"type": "FeatureCollection", "features": []}
+
         self.updated += 1
 
     def get_ee_features(self) -> Tuple[DictType[str, AnyType], DictType[str, AnyType]]:
@@ -435,18 +499,22 @@ class SeplanAoi(model.Model):
                 primary_data.get("name"),
             )
 
-        self.aoi_model.import_data(primary_data)
-        self.custom_layers = data["custom"]
+        self._loading = True
+        try:
+            self.aoi_model.import_data(primary_data)
+            self.custom_layers = data["custom"]
 
-        # if there's no aoi we just need to reset the map
-        if not primary_data["method"]:
-            self.reset_view += 1
-            return
+            # if there's no aoi we just need to reset the map
+            if not primary_data["method"]:
+                self.reset_view += 1
+                return
 
-        self.set_map += 1
+            self.set_map += 1
 
-        if auto_update:
-            self.aoi_model.set_object()
+            if auto_update:
+                self.aoi_model.set_object()
+        finally:
+            self._loading = False
 
     async def import_data_async(self, data: dict, auto_update: bool = True):
         primary_data = dict(data["primary"])
@@ -459,18 +527,22 @@ class SeplanAoi(model.Model):
                 primary_data.get("name"),
             )
 
-        self.aoi_model.import_data(primary_data)
-        self.custom_layers = data["custom"]
+        self._loading = True
+        try:
+            self.aoi_model.import_data(primary_data)
+            self.custom_layers = data["custom"]
 
-        # if there's no aoi we just need to reset the map
-        if not primary_data["method"]:
-            self.reset_view += 1
-            return
+            # if there's no aoi we just need to reset the map
+            if not primary_data["method"]:
+                self.reset_view += 1
+                return
 
-        self.set_map += 1
+            self.set_map += 1
 
-        if auto_update:
-            await self.aoi_model.set_object_async()
+            if auto_update:
+                await self.aoi_model.set_object_async()
+        finally:
+            self._loading = False
 
     def export_data(self):
         """Save the data from each of the AOIs."""

--- a/component/model/app_model.py
+++ b/component/model/app_model.py
@@ -23,6 +23,15 @@ class AppModel(HasTraits):
     close_all_dialogs = Int().tag(sync=True)
     """A counter that is incremented by the drawers to close all the dialogs"""
 
+    # MapApp dialog control — bidirectionally linked when ``model=app_model``
+    # is passed to ``MapApp.element(...)`` (see ``MapApp._setup_model_binding``).
+    # Setting ``step_open = False`` closes the active step dialog from Python.
+    current_step = Int(default_value=None, allow_none=True).tag(sync=True)
+    """The id of the active MapApp step (linked to MapApp.current_step)"""
+
+    step_open = Bool(False).tag(sync=True)
+    """Whether the active MapApp step dialog is open (linked to MapApp.step_open)"""
+
     @observe(
         "new_changes",
         "ready",

--- a/component/model/recipe.py
+++ b/component/model/recipe.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Union
 from component.scripts.file_handler import save_file
 from pathlib import Path
@@ -55,6 +56,9 @@ class Recipe(HasTraits):
 
         # link the new_changes counter to the models
         self.seplan_aoi.observe(self.update_changes, "updated")
+        # auto-assign a default name+path the first time an AOI is set, so the
+        # right-panel header has something to display and Save has a target
+        self.seplan_aoi.observe(self._auto_init_recipe_path, "updated")
         # Icall them "new_changes" because there's another "updated" trait that is
         # used to trigger the update of the view of these models.
         self.benefit_model.observe(self.update_changes, "new_changes")
@@ -68,6 +72,19 @@ class Recipe(HasTraits):
     def update_changes(self, change):
         """Increment the new_changes counter by 1."""
         self.new_changes += 1
+
+    def _auto_init_recipe_path(self, change):
+        """Assign an in-memory default path on the first AOI update.
+
+        Only fires when no recipe is loaded/saved yet (``recipe_session_path``
+        is empty). Does NOT write to disk — the file is created on the first
+        explicit Save click. This gives the right-panel header a name to
+        display from the moment the user picks an AOI.
+        """
+        if self.recipe_session_path:
+            return
+        default_name = f"recipe_{datetime.now().strftime('%Y-%m-%d-%H%M%S')}"
+        self.recipe_session_path = self.get_recipe_path(default_name)
 
     def load(self, recipe_path: str):
         """Load the recipe element in the different element of the app.

--- a/component/scripts/compute.py
+++ b/component/scripts/compute.py
@@ -1,80 +1,212 @@
-from typing import List
+import csv
+import io
+import logging
+import math
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pandas as pd
 
 import component.parameter.gui_params as param
+from component.message import cm
 from component.parameter.directory import result_dir
-from component.scripts.file_handler import save_file
+from component.parameter.file_params import layer_list
+from component.scripts.statistics import STATS_SCALE_M
 from component.types import RecipeStatsDict
 
 from sepal_ui.solara import get_current_sepal_client
 
-TYPE_OF_RESULT = {
+logger = logging.getLogger("SEPLAN")
+
+AGGREGATION_LABEL = {
+    "benefit": "mean",
+    "constraint": "coverage",
+    "cost": "sum",
+    "suitability": "area",
+}
+
+VALUE_KEY = {
     "benefit": "mean",
     "constraint": "percent",
     "cost": "sum",
-    "suitability": "sum",
 }
+
+THEME_DISPLAY = {
+    "benefit": "Benefit",
+    "constraint": "Constraint",
+    "cost": "Cost",
+    "suitability": "Suitability",
+}
+
+CSV_COLUMNS = [
+    "Recipe",
+    "Area",
+    "AOI type",
+    "Theme",
+    "Indicator",
+    "Unit",
+    "Aggregation",
+    "Value",
+]
+
+
+def _layer_label(layer_id: str) -> str:
+    """Human-readable name for a layer; falls back to a humanized layer_id."""
+    entry = cm.layers.get(layer_id) if hasattr(cm.layers, "get") else None
+    if entry is not None:
+        name = getattr(entry, "name", None) or (entry.get("name") if hasattr(entry, "get") else None)
+        if name:
+            return name
+    return layer_id.replace("_", " ").capitalize()
+
+
+def _build_unit_lookup() -> dict:
+    df = pd.read_csv(layer_list).fillna("")
+    return dict(zip(df["layer_id"], df["unit"]))
+
+
+_UNIT_LOOKUP = _build_unit_lookup()
+
+
+def _format_value(v) -> str:
+    if v is None:
+        return ""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return ""
+    if math.isnan(f) or math.isinf(f):
+        return ""
+    if f != 0 and abs(f) < 0.1:
+        return f"{f:.4g}"
+    return f"{f:.2f}"
+
+
+def _humanize_primary_area_name(area_name: str) -> str:
+    """`PER_Amazonas` → `PER — Amazonas`. Only applied to the primary AOI."""
+    if "_" in area_name:
+        first, rest = area_name.split("_", 1)
+        return f"{first} — {rest}"
+    return area_name
+
+
+def _build_rows(recipe_name: str, area_stats: dict) -> list:
+    unit_for = _UNIT_LOOKUP
+    rows = []
+
+    for idx, (area_name, area_data) in enumerate(area_stats.items()):
+        is_primary = idx == 0
+        aoi_type = "Primary" if is_primary else "Sub-region"
+        area_display = (
+            _humanize_primary_area_name(area_name) if is_primary else area_name
+        )
+
+        for category in ("benefit", "constraint", "cost"):
+            details = area_data.get(category) or []
+            value_key = VALUE_KEY[category]
+            for entry in details:
+                for layer_id, content in entry.items():
+                    raw_value = content.get("values", {}).get(value_key)
+                    # Constraints always report % of AOI covered, not the
+                    # underlying raster's native unit.
+                    unit = (
+                        "% of AOI"
+                        if category == "constraint"
+                        else unit_for.get(layer_id, "")
+                    )
+                    rows.append(
+                        {
+                            "Recipe": recipe_name,
+                            "Area": area_display,
+                            "AOI type": aoi_type,
+                            "Theme": THEME_DISPLAY[category],
+                            "Indicator": _layer_label(layer_id),
+                            "Unit": unit,
+                            "Aggregation": AGGREGATION_LABEL[category],
+                            "Value": _format_value(raw_value),
+                        }
+                    )
+
+        suit = area_data.get("suitability") or {}
+        for v in suit.get("values", []):
+            rows.append(
+                {
+                    "Recipe": recipe_name,
+                    "Area": area_display,
+                    "AOI type": aoi_type,
+                    "Theme": THEME_DISPLAY["suitability"],
+                    "Indicator": param.SUITABILITY_LEVELS[v["image"]],
+                    "Unit": "ha",
+                    "Aggregation": AGGREGATION_LABEL["suitability"],
+                    "Value": _format_value(v.get("sum")),
+                }
+            )
+
+        rows.append(
+            {
+                "Recipe": recipe_name,
+                "Area": area_display,
+                "AOI type": aoi_type,
+                "Theme": THEME_DISPLAY["suitability"],
+                "Indicator": "Total",
+                "Unit": "ha",
+                "Aggregation": AGGREGATION_LABEL["suitability"],
+                "Value": _format_value(suit.get("total")),
+            }
+        )
+
+    return rows
+
+
+def _build_metadata(recipe_name: str, area_stats: dict) -> list:
+    area_keys = list(area_stats.keys())
+    primary_name = area_keys[0]
+    sub_regions = area_keys[1:]
+
+    lines = [
+        f"# Recipe: {recipe_name}",
+        f"# Generated: {datetime.now(timezone.utc).isoformat(timespec='seconds')}",
+        f"# Primary AOI: {primary_name}",
+    ]
+    if sub_regions:
+        lines.append("# Sub-regions: " + ", ".join(sub_regions))
+    lines.append(f"# Scale (m): {STATS_SCALE_M}")
+    lines.append(f"# Areas: {len(area_keys)}")
+    return lines
 
 
 def export_as_csv(recipe_summary_stats: RecipeStatsDict):
-    # Function to create a multi-row format for each sub-category
+    """Write the dashboard summary statistics to a real CSV file.
 
-    recipe_name, summary_stats = list(recipe_summary_stats.items())[0]
+    Output layout: a metadata block of `# key: value` comment lines, followed
+    by a tabular section with the columns in `CSV_COLUMNS`. Read back with
+    `pd.read_csv(path, comment='#')`.
+    """
+    recipe_name, area_stats = next(iter(recipe_summary_stats.items()))
 
     sepal_session = get_current_sepal_client()
     if sepal_session:
         csv_folder = sepal_session.get_remote_dir("module_results/se.plan/csv_results")
     else:
-
         csv_folder = result_dir / "results"
         csv_folder.mkdir(exist_ok=True)
 
     session_results_path = (csv_folder / recipe_name).with_suffix(".csv")
 
-    formatted_data = []
-    for recipe_name, area_stats in recipe_summary_stats.items():
-        for area_name, area_data in area_stats.items():
-            for category, details in area_data.items():
-                if category == "color":
-                    continue
-                type_result = TYPE_OF_RESULT[category]
-                if isinstance(details, list):  # For 'benefit', 'constraint', 'cost'
-                    for item in details:
-                        for sub_category, value in item.items():
-                            row = {
-                                "Recipe": recipe_name,
-                                "Area": area_name,
-                                "Theme": category,
-                                "Sub-theme": sub_category,
-                                "Values": value["values"][type_result],
-                            }
-                            formatted_data.append(row)
-                elif isinstance(details, dict):  # For 'suitability'
-                    for value in details["values"]:
-                        row = {
-                            "Recipe": recipe_name,
-                            "Area": area_name,
-                            "Theme": category,
-                            "Sub-theme": param.SUITABILITY_LEVELS[value["image"]],
-                            "Values": value["sum"],
-                        }
-                        formatted_data.append(row)
-                    # Adding total suitability as a separate row
-                    formatted_data.append(
-                        {
-                            "Recipe": recipe_name,
-                            "Area": area_name,
-                            "Theme": "Total",
-                            "Sub-theme": "Total",
-                            "Values": details["total"],
-                        }
-                    )
+    metadata_lines = _build_metadata(recipe_name, area_stats)
+    rows = _build_rows(recipe_name, area_stats)
 
-    formatted_df = pd.DataFrame(formatted_data)
+    buf = io.StringIO()
+    buf.write("\n".join(metadata_lines))
+    buf.write("\n")
+    writer = csv.DictWriter(buf, fieldnames=CSV_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    text = buf.getvalue()
 
-    save_file(
-        session_results_path, formatted_df.to_dict(orient="records"), sepal_session
-    )
+    if sepal_session:
+        sepal_session.set_file(str(session_results_path), text, overwrite=True)
+    else:
+        Path(session_results_path).write_text(text, encoding="utf-8")
 
     return session_results_path

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -194,7 +194,6 @@ async def get_limits_async(
 
 
 def get_gee_recipe_folder(recipe_name: str, gee_interface: GEEInterface) -> Path:
-    """Create a folder for the recipe in GEE"""
-
+    """Create a folder for the recipe in GEE."""
     recipe_folder = Path("seplan") / recipe_name
-    return Path(gee_interface.create_folder(recipe_folder))
+    return Path(gee_interface.create_folder(recipe_folder.as_posix()))

--- a/component/scripts/plots.py
+++ b/component/scripts/plots.py
@@ -267,7 +267,12 @@ def get_bars_chart(
         ),
         xAxis=XAxis(type="value", max=max_value),
         series=series,
-        tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
+        tooltip=Tooltip(
+            trigger="axis",
+            axisPointer={"type": "shadow"},
+            appendToBody=True,
+            confine=True,
+        ),
         legend=Legend() if show_legend else None,
     )
 
@@ -315,7 +320,12 @@ def get_stacked_bars_chart(
         ),
         xAxis=XAxis(type="value", axisLabel=axis_label_x, splitLine={"show": False}),
         series=bars,
-        tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
+        tooltip=Tooltip(
+            trigger="axis",
+            axisPointer={"type": "shadow"},
+            appendToBody=True,
+            confine=True,
+        ),
     )
     # style={"height": f"{height}px"}
     return EChartsWidget(
@@ -361,7 +371,12 @@ def get_individual_charts(summary_results: SummaryStatsDict, theme_toggle=None):
             # yAxis=YAxis(type="category", rotate=90, data=[region]),
             yAxis=YAxis(type="category", data=[region]),
             series=bars,
-            tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
+            tooltip=Tooltip(
+                trigger="axis",
+                axisPointer={"type": "shadow"},
+                appendToBody=True,
+                confine=True,
+            ),
             grid=Grid(height="60px"),
             toolbox=Toolbox(show=True),
         )

--- a/component/scripts/statistics.py
+++ b/component/scripts/statistics.py
@@ -16,6 +16,10 @@ from component.types import (
 
 logger = logging.getLogger("SEPLAN")
 
+STATS_SCALE_M = 100
+"""Scale (in meters) used by every reduceRegion in this module. The dashboard
+CSV export reads this constant to report the actual computation scale."""
+
 
 def is_main_aoi(main_aoi_name, aoi_name) -> bool:
     """Check if the aoi is the main aoi."""
@@ -368,7 +372,7 @@ def get_image_stats(image, mask, geom):
         .reduceRegion(
             reducer=ee.Reducer.sum().group(1, "image"),
             geometry=geom,
-            scale=100,
+            scale=STATS_SCALE_M,
             maxPixels=1e12,
         )
         .get("groups")
@@ -396,7 +400,7 @@ def get_image_percent_cover_pixelarea(
         .reduceRegion(
             reducer=ee.Reducer.sum().group(1, "image"),
             geometry=aoi,
-            scale=100,
+            scale=STATS_SCALE_M,
             maxPixels=1e12,
         )
         .get("groups")
@@ -461,7 +465,7 @@ def get_image_mean(image, aoi, mask, name, main_aoi) -> Dict[str, MeanStatsDict]
         image.reduceRegion(
             reducer=reducer,
             geometry=aoi,
-            scale=100,
+            scale=STATS_SCALE_M,
             maxPixels=1e13,
         )
     )
@@ -487,7 +491,7 @@ def get_image_sum(image, aoi, mask, name) -> Dict[str, SumStatsDict]:
         .reduceRegion(
             reducer=ee.Reducer.sum(),
             geometry=aoi,
-            scale=100,
+            scale=STATS_SCALE_M,
             maxPixels=1e13,
         )
         .get("area")
@@ -499,7 +503,7 @@ def get_image_sum(image, aoi, mask, name) -> Dict[str, SumStatsDict]:
         .reduceRegion(
             reducer=ee.Reducer.sum(),
             geometry=aoi,
-            scale=100,
+            scale=STATS_SCALE_M,
             maxPixels=1e13,
         )
     )
@@ -507,7 +511,7 @@ def get_image_sum(image, aoi, mask, name) -> Dict[str, SumStatsDict]:
     total_img = image.reduceRegion(
         reducer=ee.Reducer.sum(),
         geometry=aoi,
-        scale=100,
+        scale=STATS_SCALE_M,
         maxPixels=1e13,
     )
 

--- a/component/tile/custom_aoi_tile.py
+++ b/component/tile/custom_aoi_tile.py
@@ -32,6 +32,7 @@ class AoiView(sw.Layout):
         map_: SepalMap,
         gee_interface: GEEInterface = None,
         recipe: Recipe = None,
+        app_model=None,
     ):
         if not recipe:
             recipe = Recipe()
@@ -39,12 +40,19 @@ class AoiView(sw.Layout):
         self._metadata = {"mount_id": "aoi_tile"}
         self.gee_interface = gee_interface
         self.map_ = map_
+        # Keep the wrapper reference — ``SeplanAoiView.model`` is the inner
+        # ``AoiModel`` (set via super().__init__), so the LMIC traits live
+        # on this object instead.
+        self.seplan_aoi = recipe.seplan_aoi
 
         super().__init__()
 
         # Build the aoi view with our custom aoi_model
         self.view = SeplanAoiView(
-            model=recipe.seplan_aoi, map_=self.map_, gee_interface=gee_interface
+            model=recipe.seplan_aoi,
+            map_=self.map_,
+            gee_interface=gee_interface,
+            app_model=app_model,
         )
 
         self.children = [self.view]
@@ -52,10 +60,21 @@ class AoiView(sw.Layout):
         self.view.observe(self._check_lmic, "updated")
 
     def _check_lmic(self, _):
-        """Every time a new aoi is set check if it fits the LMIC country list."""
-        # check over the lmic country number
+        """Every time a new aoi is set check if it fits the LMIC country list.
+
+        The admin branch is pure-Python (pygaul + a CSV read) and runs inline.
+        The DRAW/SHAPE branch needs GEE, so it's dispatched as a background
+        task — this keeps the observer safe to fire from any thread (notably
+        from inside ``SeplanAoiView._auto_submit_async`` which already runs on
+        the GEE event loop and would deadlock on a sync ``get_info`` call).
+
+        Writes the verdict to ``seplan_aoi.aoi_lmic_valid`` and bumps
+        ``aoi_lmic_checked`` so dialog-close gating and right-panel
+        action-blocking can react.
+        """
+        seplan_aoi = self.seplan_aoi  # SeplanAoi wrapper
         if self.view.model.admin:
-            logger.info(f"Checking if the aoi is in the LMIC country list")
+            logger.info("Checking if the aoi is in the LMIC country list")
             code = str(self.view.model.admin)
 
             # Resolve the admin code (level 0, 1, or 2) to its ISO3 country code
@@ -70,32 +89,68 @@ class AoiView(sw.Layout):
                 | (df["gaul2_code"] == code)
             ]["iso3_code"].iloc[0]
 
-            # read the country file and match by ISO3
             lmic_iso3 = pd.read_csv(cp.country_list).ISO3.astype(str)
-            included = (lmic_iso3 == iso3_code).any()
+            included = bool((lmic_iso3 == iso3_code).any())
+            if not included:
+                self.view.alert.add_msg(cm.aoi.not_lmic, "warning")
+            seplan_aoi.aoi_lmic_valid = included
+            seplan_aoi.aoi_lmic_checked += 1
+            return self
 
-        # check if the aoi is in the LMIC
-        else:
-            lmic_raster = ee.Image(
-                "projects/john-ee-282116/assets/fao-restoration/misc/lmic_global_1k"
-            )
+        # Non-admin (DRAW / SHAPE / ASSET) — flip valid=False optimistically
+        # while the async GEE check runs. This blocks the dialog auto-close
+        # and the right-panel actions until a verdict lands; on success we
+        # set valid=True before bumping ``aoi_lmic_checked`` so the close
+        # observer sees the right value.
+        seplan_aoi.aoi_lmic_valid = False
+        task = self.gee_interface.create_task(
+            func=self._check_lmic_gee_async,
+            key="lmic_check_gee",
+            on_error=self._on_gee_lmic_error,
+        )
+        self._lmic_task = task  # keep ref so it isn't garbage-collected
+        task.start()
+        return self
 
-            aoi_ee_geom = self.view.model.feature_collection.geometry()
+    def _on_gee_lmic_error(self, exc: Exception):
+        """Treat GEE check failures as 'unknown' — leave aoi_lmic_valid False.
 
-            empt = ee.Image().byte()
-            aoi_ee_raster = empt.paint(aoi_ee_geom, 1)
+        The user can still see the warning (logged here) but the right-panel
+        actions stay disabled until a successful re-check. Bumping the
+        counter releases any waiters (e.g. the dialog-close observer).
+        """
+        logger.warning(f"LMIC check failed: {exc}")
+        self.seplan_aoi.aoi_lmic_checked += 1
 
-            bit_test = aoi_ee_raster.add(lmic_raster).reduceRegion(
-                reducer=ee.Reducer.bitwiseAnd(),
-                geometry=aoi_ee_geom,
-                scale=1000,
-                bestEffort=True,
-                maxPixels=1e13,
-            )
-            # test if bitwiseAnd is 2 (1 is partial coverage, 0 no coverage)
-            included = self.gee_interface.get_info(
+    async def _check_lmic_gee_async(self):
+        """Async LMIC overlap check for non-admin AOIs.
+
+        Drives ``get_info_async`` on the GEE event loop. Safe to launch from
+        either the kernel thread or the GEE thread.
+        """
+        seplan_aoi = self.seplan_aoi
+        lmic_raster = ee.Image(
+            "projects/john-ee-282116/assets/fao-restoration/misc/lmic_global_1k"
+        )
+        aoi_ee_geom = seplan_aoi.feature_collection.geometry()
+
+        empt = ee.Image().byte()
+        aoi_ee_raster = empt.paint(aoi_ee_geom, 1)
+
+        bit_test = aoi_ee_raster.add(lmic_raster).reduceRegion(
+            reducer=ee.Reducer.bitwiseAnd(),
+            geometry=aoi_ee_geom,
+            scale=1000,
+            bestEffort=True,
+            maxPixels=1e13,
+        )
+        # bitwiseAnd == 2 means full LMIC coverage (1 partial, 0 none).
+        included = bool(
+            await self.gee_interface.get_info_async(
                 ee.Algorithms.IsEqual(bit_test.getNumber("constant"), 2),
             )
-
-        included or self.view.alert.add_msg(cm.aoi.not_lmic, "warning")
-        return self
+        )
+        if not included:
+            self.view.alert.add_msg(cm.aoi.not_lmic, "warning")
+        seplan_aoi.aoi_lmic_valid = included
+        seplan_aoi.aoi_lmic_checked += 1

--- a/component/tile/dashboard_components.py
+++ b/component/tile/dashboard_components.py
@@ -29,7 +29,12 @@ class MapComputeComponent(sw.Layout):
     """Component for map computation functionality"""
 
     def __init__(
-        self, recipe: Recipe, map_, gee_interface: GEEInterface, alert: Alert, **kwargs
+        self,
+        recipe: Recipe,
+        map_,
+        gee_interface: GEEInterface,
+        alert: Alert,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.recipe = recipe

--- a/component/tile/recipe_tile.py
+++ b/component/tile/recipe_tile.py
@@ -182,12 +182,21 @@ class RecipeView(sw.Layout):
             ),
         ]
 
+        # Recipe → view: keep the CardSave name field in sync with whatever
+        # writes ``recipe.recipe_session_path`` (auto-init in ``Recipe`` and
+        # the right-panel header's save button). One-way avoids the link's
+        # initial sync wiping a freshly auto-init'd path with this view's
+        # empty default.
         directional_link(
-            (self, "recipe_session_path"), (self.recipe, "recipe_session_path")
+            (self.recipe, "recipe_session_path"), (self, "recipe_session_path")
         )
 
         # link the current session path with save_card.recipe_name
         self.observe(self.session_path_handler, "recipe_session_path")
+        # Seed the save card with whatever path is already on the recipe
+        # (e.g. set by the auto-init observer before this view existed).
+        if self.recipe.recipe_session_path:
+            self.recipe_session_path = self.recipe.recipe_session_path
 
         # Capture errors with alert (we have to decorate before the events definition)
         self.new_event = loading_button(alert=self.alert, button=self.card_new.btn)(
@@ -224,8 +233,11 @@ class RecipeView(sw.Layout):
         """handle current session path and link its value with save_card.recipe_name."""
         # we only need to show the name, not the full path, but we have to keep the full path
         # to save the recipe
-
-        self.card_save.recipe_name = str(Path(change["new"]).stem)
+        new_path = change["new"]
+        if not new_path:
+            self.card_save.recipe_name = ""
+            return
+        self.card_save.recipe_name = str(Path(new_path).stem)
 
     @switch("disabled", on_widgets=["card_new", "card_load", "card_save"])
     @switch("loading", on_widgets=["card_new"])

--- a/component/tile/right_panel.py
+++ b/component/tile/right_panel.py
@@ -11,6 +11,7 @@ from component.tile.dashboard_components import (
     MapDownloadComponent,
 )
 from component.widget.alert_state import Alert, AlertDialog
+from component.widget.recipe_header import RecipeHeader
 
 
 def get_right_panel_content(
@@ -53,6 +54,8 @@ def get_right_panel_content(
 
     map_download_component = MapDownloadComponent(recipe=recipe, alert=shared_alert)
 
+    recipe_header = RecipeHeader(recipe=recipe, alert=shared_alert)
+
     # Right panel configuration
     config = {
         "title": "Compute results",
@@ -64,6 +67,7 @@ def get_right_panel_content(
 
     # Add dashboard components
     content_data = [
+        {"content": [recipe_header], "divider": True},
         {"content": [AdminButton(models=recipe.models) if not no_admin else None]},
         {
             "title": "Compute Restoration Map",

--- a/component/tile/right_panel.py
+++ b/component/tile/right_panel.py
@@ -49,12 +49,35 @@ def get_right_panel_content(
     )
 
     map_compute_component = MapComputeComponent(
-        recipe=recipe, map_=map_, gee_interface=gee_interface, alert=shared_alert
+        recipe=recipe,
+        map_=map_,
+        gee_interface=gee_interface,
+        alert=shared_alert,
     )
 
     map_download_component = MapDownloadComponent(recipe=recipe, alert=shared_alert)
 
     recipe_header = RecipeHeader(recipe=recipe, alert=shared_alert)
+
+    # Buttons that require a valid LMIC AOI. Disabled while
+    # ``recipe.seplan_aoi.aoi_lmic_valid`` is False so the user can't kick
+    # off compute/export against an out-of-scope AOI.
+    lmic_gated_buttons = [
+        map_compute_component.btn_compute,
+        map_download_component.btn_download,
+        download_component.btn_download,
+        dashboard_compute_component.btn_dashboard,
+        dashboard_compute_component.btn_view_dashboard,
+        compare_component.btn_compare,
+    ]
+
+    def _sync_lmic_gate(*_):
+        disabled = not recipe.seplan_aoi.aoi_lmic_valid
+        for btn in lmic_gated_buttons:
+            btn.disabled = disabled
+
+    recipe.seplan_aoi.observe(_sync_lmic_gate, "aoi_lmic_valid")
+    _sync_lmic_gate()
 
     # Right panel configuration
     config = {

--- a/component/tile/right_panel.py
+++ b/component/tile/right_panel.py
@@ -100,6 +100,16 @@ def get_right_panel_content(
             "description": "Generate the restoration suitability map based on the benefits, constraints and costs layers and configuration.",
         },
         {
+            "title": "Custom geometries",
+            "icon": "mdi-shape-polygon-plus",
+            "content": [map_.btn_custom_geom],
+            "divider": True,
+            "description": (
+                "Refine the analysis by adding sub-areas inside your primary "
+                "AOI. Draw, import a shape, or pick an admin unit below it."
+            ),
+        },
+        {
             "title": "Export Results",
             "icon": "mdi-download",
             "content": [map_download_component, download_component],

--- a/component/widget/admin_aoi_dialog.py
+++ b/component/widget/admin_aoi_dialog.py
@@ -1,0 +1,312 @@
+"""Dialog to add a sub-AOI by picking an admin unit inside the primary AOI.
+
+Admin hierarchy guarantees structural containment, so the GEE containment
+check used by drawn / imported geometries can be skipped for this path.
+The only round-trip is one ``getInfo`` to materialize the picked admin
+unit's geometry as GeoJSON for the ipyleaflet GeoJSON layer.
+"""
+
+import logging
+
+import pygaul
+import sepal_ui.sepalwidgets as sw
+from sepal_ui.aoi.aoi_view import AdminField
+from sepal_ui.scripts.gee_interface import GEEInterface
+
+from component.frontend.icons import icon
+from component.widget.base_dialog import BaseDialog
+from component.widget.buttons import TextBtn
+
+logger = logging.getLogger("SEPLAN")
+
+
+def _admin_level(method: str) -> int:
+    """Return the integer admin level (0-2) for an ADMIN method, or -1."""
+    if not method or not method.startswith("ADMIN"):
+        return -1
+    try:
+        return int(method[5:])
+    except (ValueError, IndexError):
+        return -1
+
+
+def _is_admin_eligible(method: str) -> bool:
+    """Whether a primary AOI with ``method`` allows an admin sub-area pick."""
+    level = _admin_level(method)
+    return 0 <= level <= 1  # ADMIN0/ADMIN1 → ADMIN1/ADMIN2 child available
+
+
+class AdminAoiDialog(BaseDialog):
+    """Pick an admin unit one level below the primary AOI as a sub-AOI."""
+
+    def __init__(
+        self,
+        custom_aoi_dialog,
+        gee_interface: GEEInterface,
+        map_,
+    ):
+        super().__init__()
+        self.attributes = {"id": "admin_aoi_dialog"}
+
+        self.custom_aoi_dialog = custom_aoi_dialog
+        self.gee_interface = gee_interface
+        self.map_ = map_
+
+        # Selectors built on each ``open_dialog`` so they reflect the
+        # current primary AOI / available child levels. ``_cascade_fields``
+        # holds one ``AdminField`` per intermediate level — for a target
+        # level deeper than ``parent_level + 1`` the user picks each level
+        # in turn (e.g. Departamento, then Municipio).
+        self.w_level: "sw.Select | None" = None
+        self._cascade_fields: list = []
+        self._primary_admin: str = ""
+        self._parent_level: int = -1
+        self._admin_task = None
+        # Caller-supplied dialog to re-open if the user cancels out of this
+        # one — used to restore the consolidated Custom Geometries picker
+        # after a back-out.
+        self._return_to = None
+
+        title = sw.CardTitle(children=["Add admin sub-area"])
+        self.header = sw.Html(
+            tag="p",
+            class_="ma-2",
+            children=[""],
+        )
+        self.body_card = sw.CardText(children=[self.header])
+        self.alert = sw.Alert()
+
+        self.btn = TextBtn("Add", gliph=icon("plus"))
+        btn_cancel = TextBtn("Cancel", outlined=True)
+        action = sw.CardActions(
+            children=[sw.Spacer(), btn_cancel, self.btn],
+        )
+        card = sw.Card(
+            class_="ma-0",
+            children=[title, self.body_card, self.alert, action],
+        )
+        self.children = [card]
+
+        btn_cancel.on_event("click", lambda *_: self._cancel())
+        self.btn.on_event("click", self.on_submit)
+
+    def _cancel(self, *_):
+        """Close the dialog and re-open the caller dialog if any."""
+        return_to = self._return_to
+        self._return_to = None
+        self.close_dialog()
+        if return_to is not None:
+            return_to.open_dialog()
+
+    def open_dialog(self, *_, return_to=None):
+        """(Re)build the level + admin selectors and show the dialog.
+
+        Args:
+            return_to: Optional dialog to re-open if the user cancels — used
+                to preserve a back-navigation breadcrumb from the
+                consolidated Custom Geometries picker.
+        """
+        if return_to is not None:
+            self._return_to = return_to
+        primary = self.map_.aoi_model.aoi_model
+        method = getattr(primary, "method", "") or ""
+        primary_admin = getattr(primary, "admin", "") or ""
+        primary_name = (getattr(primary, "name", "") or "").replace("_", " ")
+
+        self.alert.reset()
+        self.btn.disabled = False
+        self.btn.loading = False
+        self._primary_admin = primary_admin
+
+        if not _is_admin_eligible(method):
+            self._show_message(
+                "The primary AOI is not an administrative area, so admin "
+                "sub-units are unavailable. Pick a country or first-level "
+                "admin as your primary AOI to use this option."
+            )
+            super().open_dialog()
+            return
+
+        # Level options: every admin level strictly deeper than the primary.
+        parent_level = _admin_level(method)
+        self._parent_level = parent_level
+        available_levels = [lvl for lvl in (1, 2) if lvl > parent_level]
+        logger.info(
+            "Admin sub-area open: method=%s parent_level=%s available_levels=%s",
+            method,
+            parent_level,
+            available_levels,
+        )
+
+        # Use string values to avoid Vuetify's strict-equality oddities when
+        # comparing the v-model against item values of mixed numeric types.
+        self.w_level = sw.Select(
+            v_model=str(available_levels[0]),
+            items=[
+                {"text": f"Admin level {lvl}", "value": str(lvl)}
+                for lvl in available_levels
+            ],
+            label="Sub-area level",
+            class_="mb-2",
+            clearable=False,
+        )
+        self.w_level.observe(self._on_level_change, "v_model")
+
+        try:
+            self._cascade_fields = self._build_cascade(available_levels[0])
+        except Exception as exc:
+            logger.exception("Failed to build admin sub-area selector")
+            self._show_message(f"Could not load admin sub-units: {exc}")
+            super().open_dialog()
+            return
+
+        self.header.children = [
+            f"Pick an administrative sub-area inside "
+            f"{primary_name or 'your primary AOI'}:"
+        ]
+        self.body_card.children = [
+            self.header,
+            self.w_level,
+            *self._cascade_fields,
+        ]
+
+        super().open_dialog()
+
+    def _build_cascade(self, target_level: int) -> list:
+        """Build the chain of ``AdminField`` widgets up to ``target_level``.
+
+        - First field (``parent_level + 1``) is filtered by the primary AOI's
+          admin code.
+        - Subsequent fields use pysepal's ``AdminField`` parent observer,
+          which auto-refreshes the children when the parent's ``v_model``
+          changes — so picking a Departamento populates the Municipio
+          selector with that Departamento's children, etc.
+        """
+        fields: list = []
+        for lvl in range(self._parent_level + 1, target_level + 1):
+            if not fields:
+                field = AdminField(level=lvl, gee=True)
+                field.get_items(filter_=self._primary_admin)
+            else:
+                field = AdminField(level=lvl, parent=fields[-1], gee=True)
+            fields.append(field)
+        return fields
+
+    def _on_level_change(self, change: dict):
+        """Rebuild the cascade when the target child level changes."""
+        raw = change.get("new")
+        if raw is None or self.w_level is None:
+            return
+        try:
+            new_level = int(raw)
+        except (TypeError, ValueError):
+            return
+        try:
+            self._cascade_fields = self._build_cascade(new_level)
+        except Exception as exc:
+            logger.exception("Failed to rebuild admin sub-area selector")
+            self.alert.add_msg(
+                f"Could not load admin level {new_level} units: {exc}",
+                type_="error",
+            )
+            return
+        self.body_card.children = [
+            self.header,
+            self.w_level,
+            *self._cascade_fields,
+        ]
+
+    def on_submit(self, *_):
+        """Resolve the picked admin unit and forward to ``CustomAoiDialog``.
+
+        For a multi-level cascade (e.g. ADMIN0 → level 2) every field along
+        the chain must have a value: the user has to pick the level 1 unit
+        before the level 2 dropdown is populated. We surface a clear error
+        if any field is left empty so the user knows what to fill in.
+        """
+        if not self._cascade_fields:
+            self.alert.add_msg("Please pick an admin unit.", type_="error")
+            return
+
+        for idx, field in enumerate(self._cascade_fields):
+            if not field.v_model:
+                level = self._parent_level + 1 + idx
+                self.alert.add_msg(
+                    f"Please pick an admin level {level} unit before "
+                    "submitting.",
+                    type_="error",
+                )
+                return
+
+        final = self._cascade_fields[-1]
+        admin_code = final.v_model
+        admin_text = next(
+            (
+                item.get("text", admin_code)
+                for item in (final.items or [])
+                if item.get("value") == admin_code
+            ),
+            admin_code,
+        )
+
+        self.btn.disabled = True
+        self.btn.loading = True
+        self.alert.reset()
+
+        self._admin_code = admin_code
+        self._admin_text = admin_text
+        self._admin_task = self.gee_interface.create_task(
+            func=self._resolve_admin_async,
+            key="admin_subaoi_resolve",
+            on_done=self._on_resolved,
+            on_error=self._on_resolve_error,
+        )
+        self._admin_task.start()
+
+    async def _resolve_admin_async(self):
+        """Materialize the picked admin unit as a GeoJSON FeatureCollection.
+
+        Returns the GeoJSON dict ready to feed into
+        ``CustomAoiDialog.on_new_geom``. We use ``get_info_async`` so the
+        resolution doesn't block the kernel — pygaul is lazy and only the
+        ``getInfo`` round-trip is slow.
+        """
+        fc = pygaul.AdmItems(admin=self._admin_code)
+        return await self.gee_interface.get_info_async(fc)
+
+    def _on_resolved(self, geo_json: dict):
+        """Forward the materialized geometry to ``CustomAoiDialog``."""
+        self.btn.disabled = False
+        self.btn.loading = False
+        if not geo_json or not geo_json.get("features"):
+            self.alert.add_msg(
+                "The selected admin unit returned no geometry. "
+                "Try a different unit.",
+                type_="error",
+            )
+            return
+
+        # Hand off to the existing rename + commit dialog. The skip flag tells
+        # CustomAoiDialog not to run the GEE containment check — admin
+        # hierarchy gives us structural containment for free.
+        self.close_dialog()
+        self.custom_aoi_dialog.on_new_geom(
+            feature_collection=geo_json,
+            name=self._admin_text or self._admin_code,
+            skip_containment_check=True,
+        )
+
+    def _on_resolve_error(self, exc: Exception):
+        self.btn.disabled = False
+        self.btn.loading = False
+        logger.exception("Admin sub-area resolution failed", exc_info=exc)
+        self.alert.add_msg(
+            f"Could not load the selected admin unit: {exc}",
+            type_="error",
+        )
+
+    def _show_message(self, text: str):
+        """Render a plain message in place of the selector."""
+        self.body_card.children = [
+            sw.Html(tag="p", class_="ma-2", children=[text])
+        ]

--- a/component/widget/custom_aoi_dialog.py
+++ b/component/widget/custom_aoi_dialog.py
@@ -1,5 +1,7 @@
+import logging
 from copy import deepcopy
 
+import ee
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_hex
 from component.frontend.icons import icon
@@ -11,7 +13,15 @@ from component.widget import custom_widgets as cw
 from component.widget.base_dialog import BaseDialog
 from component.widget.buttons import TextBtn
 
+from .custom_geometries_dialog import CustomGeometriesTable
 from .map import SeplanMap
+
+logger = logging.getLogger("SEPLAN")
+
+# Tolerance (in m²) for the "outside primary AOI" check. Geoman polygons can
+# carry sub-meter rounding error vs. the primary AOI boundary, so anything
+# under 1 m² of leakage is treated as inside.
+_CONTAINMENT_TOLERANCE_M2 = 1.0
 
 
 class CustomAoiDialog(BaseDialog):
@@ -39,12 +49,22 @@ class CustomAoiDialog(BaseDialog):
                 self.btn,
             ],
         )
-        text = sw.CardText(children=[table, self.save_input])
+        # Alert area for containment-check errors. Stays empty in the happy path.
+        self.alert = sw.Alert()
+        text = sw.CardText(children=[table, self.save_input, self.alert])
         btn_cancel = TextBtn(cm.map.dialog.drawing.cancel, outlined=True)
         action = sw.CardActions(children=[sw.Spacer(), btn_cancel])
         card = sw.Card(class_="ma-0", children=[title, text, action])
 
         self.children = [card]
+
+        # Holds the in-flight validation task between kick-off and completion
+        self._validate_task = None
+
+        # Set by ``on_new_geom`` when the admin-sub flow forwards a feature
+        # whose containment is structurally guaranteed; ``on_save_geom``
+        # honors it by bypassing the GEE check.
+        self._skip_containment_check = False
 
         # add js behavior
         btn_cancel.on_event("click", self.on_cancel)
@@ -53,19 +73,24 @@ class CustomAoiDialog(BaseDialog):
         self.map_.observe(self.on_new_geom, "new_geom")
 
     def on_save_geom(self, *_):
-        """Updates map_.custom_layers with the new geometry."""
-        # Get all the fc in the map_.dc, there should be only one
+        """Stage the candidate features and kick off the GEE containment check.
 
+        The actual append to ``map_.custom_layers`` happens in
+        ``_commit_save`` once ``_validate_async`` confirms every drawn /
+        imported feature lies within the primary AOI. The dialog stays open
+        on validation failure so the user can adjust without losing context.
+        """
         if self.feature:
             features = self.feature["features"]
-
             # Increase the new_geom counter but don't trigger the event
             self.map_.unobserve(self.on_new_geom, "new_geom")
             self.map_.new_geom += 1
             self.map_.observe(self.on_new_geom, "new_geom")
-
         else:
             features = self.map_.dc.to_json()["features"]
+
+        if not features:
+            return
 
         geom_number = self.map_.new_geom
         aoi_color = to_hex(plt.cm.tab10(geom_number))
@@ -74,7 +99,6 @@ class CustomAoiDialog(BaseDialog):
             "color": aoi_color,
             "fillColor": aoi_color,
         }
-
         for feature in features:
             feature["properties"]["id"] = geom_number
             feature["properties"]["name"] = self.w_name.v_model
@@ -84,21 +108,104 @@ class CustomAoiDialog(BaseDialog):
                 "fillOpacity": 0.4,
                 "weight": 2,
             }
-        current_feats = deepcopy(self.map_.custom_layers)
-        current_feats["features"] += features
 
-        # Trigger the change in the custom_layers dict
-        self.map_.custom_layers = current_feats
+        self._candidate_features = features
+        self.alert.reset()
 
-        # Remove all the geometries from the map_.dc and close the dialog
+        gee_interface = getattr(self.map_, "gee_interface", None)
+        primary_fc = getattr(self.map_.aoi_model, "feature_collection", None)
+
+        # Skip the GEE round-trip in any of:
+        #   - No GEE session / no primary AOI (defensive fallback).
+        #   - The admin-sub path opted out (containment is structural).
+        if (
+            self._skip_containment_check
+            or gee_interface is None
+            or primary_fc is None
+        ):
+            self._commit_save()
+            return
+
+        self.btn.disabled = True
+        self.btn.loading = True
+        self._validate_task = gee_interface.create_task(
+            func=self._validate_async,
+            key="custom_geom_validate",
+            on_done=self._on_validate_done,
+            on_error=self._on_validate_error,
+        )
+        self._validate_task.start()
+
+    async def _validate_async(self):
+        """Return the count of staged features that fall outside the primary AOI."""
+        primary_fc = self.map_.aoi_model.feature_collection
+        primary_geom = primary_fc.geometry()
+        gee_interface = self.map_.gee_interface
+
+        outside_count = 0
+        for feat in self._candidate_features:
+            child = ee.Geometry(feat["geometry"])
+            outside_area = await gee_interface.get_info_async(
+                child.difference(primary_geom, maxError=1).area()
+            )
+            if outside_area is not None and outside_area > _CONTAINMENT_TOLERANCE_M2:
+                outside_count += 1
+        return outside_count
+
+    def _on_validate_done(self, outside_count: int):
+        """Commit on full containment, otherwise surface the failure."""
+        self.btn.disabled = False
+        self.btn.loading = False
+        if outside_count > 0:
+            noun = "geometry" if outside_count == 1 else "geometries"
+            verb = "is" if outside_count == 1 else "are"
+            self.alert.add_msg(
+                f"{outside_count} {noun} {verb} outside the primary area of "
+                "interest. Adjust the drawing (or pick a different AOI) and "
+                "try again.",
+                type_="error",
+            )
+            return
+        self._commit_save()
+
+    def _on_validate_error(self, exc: Exception):
+        """Surface the GEE error in the dialog without silently saving."""
+        self.btn.disabled = False
+        self.btn.loading = False
+        logger.exception("Custom geometry validation failed", exc_info=exc)
+        self.alert.add_msg(
+            f"Could not verify the geometry against the primary AOI: {exc}",
+            type_="error",
+        )
+
+    def _commit_save(self):
+        """Append validated features to ``map_.custom_layers`` and close."""
+        features = getattr(self, "_candidate_features", None) or []
+        if features:
+            current_feats = deepcopy(self.map_.custom_layers)
+            current_feats["features"] += features
+            self.map_.custom_layers = current_feats
+        self._candidate_features = None
         self.on_cancel()
 
     def on_cancel(self, *_):
-        """Remove all the geometries from the map_.dc."""
-        self.map_.dc.clear()
+        """Clear any in-progress drawing and remove the Geoman toolbar.
+
+        ``dc.clear()`` only resets the layer data; ``dc.hide()`` also pops
+        the toolbar off ``map_.controls`` so the user gets a clean map back
+        after committing or cancelling the custom geometry.
+        """
+        self.map_.dc.hide()
 
         # Clear any feature that was selected
         self.feature = None
+        self._candidate_features = None
+        self._skip_containment_check = False
+
+        # Reset transient validation UI
+        self.btn.disabled = False
+        self.btn.loading = False
+        self.alert.reset()
 
         # Close the dialog
         self.close_dialog()
@@ -114,14 +221,26 @@ class CustomAoiDialog(BaseDialog):
 
         super().open_dialog()
 
-    def on_new_geom(self, *_, feature_collection: dict = None, name: str = None):
-        """Read the aoi and give an default name.
+    def on_new_geom(
+        self,
+        *_,
+        feature_collection: dict = None,
+        name: str = None,
+        skip_containment_check: bool = False,
+    ):
+        """Read the aoi and give a default name.
 
-        It will manage the new geometries drawn by the user and the custom ones
-        imported by the user (using ImportAoiDialog)
+        Manages new geometries drawn by the user, custom ones imported via
+        ``ImportAoiDialog``, and admin sub-areas forwarded from
+        ``AdminAoiDialog``.
 
         Args:
-            aoi_model (AoiModel): Aoi Model when using the import aoi dialog
+            feature_collection: Optional GeoJSON ``FeatureCollection`` dict
+                from the import / admin paths.
+            name: Suggested name when ``feature_collection`` is provided.
+            skip_containment_check: If True, ``on_save_geom`` will skip the
+                GEE containment check. Used by the admin-sub path where
+                hierarchy guarantees the geometry sits inside the primary AOI.
         """
         # Count the number of geometries in map_.custom_layers
         index = len(self.map_.custom_layers["features"]) + 1
@@ -132,117 +251,6 @@ class CustomAoiDialog(BaseDialog):
             aoi_name = f"Custom_{name}"
             self.feature = feature_collection
 
+        self._skip_containment_check = skip_containment_check
         self.w_name.v_model = aoi_name
         self.open_dialog(new_geom=True)
-
-
-class CustomGeometriesTable(sw.Layout):
-    def __init__(self, map_: SeplanMap) -> None:
-        self.class_ = "d-block"
-        self.attributes = {"id": "custom_geometries_table"}
-        self.no_items = cm.map.dialog.drawing.table.no_geometries
-
-        # create the table
-        super().__init__()
-
-        self.map_ = map_
-
-        # generate header using the translator
-        headers = sw.Html(
-            tag="tr",
-            children=[
-                sw.Html(tag="th", children=[title])
-                for title in cp.custom_geom_table_headers.values()
-            ],
-        )
-
-        self.tbody = sw.Html(attributes={"id": "tbody"}, tag="tbody", children=[])
-        self.set_rows()
-
-        # create the table
-        self.table = sw.SimpleTable(
-            dense=False,
-            children=[
-                sw.Html(tag="thead", children=[headers]),
-                self.tbody,
-            ],
-        )
-
-        self.children = [self.table]
-
-        # add js behavior
-        self.map_.observe(self.set_rows, "custom_layers")
-
-    def set_rows(self, *args):
-        """Add, remove or update rows in the table."""
-        # We don't want to recreate all the elements of the table each time since
-        # that's so expensive (specially the set_limits method)
-
-        view_layers = [
-            row.layer_id
-            for row in self.tbody.children
-            if isinstance(row, CustomGeometryRow)
-        ]
-        map_layers = [
-            lyr.get("properties")["id"] for lyr in self.map_.custom_layers["features"]
-        ]
-
-        new_ids = [id_ for id_ in map_layers if id_ not in view_layers]
-        old_ids = [id_ for id_ in view_layers if id_ not in map_layers]
-
-        if new_ids:
-            for new_id in new_ids:
-                row = CustomGeometryRow(self.map_, new_id)
-                # drop no items if it's in the table
-
-                new_items = [
-                    chld for chld in self.tbody.children if chld != self.no_items
-                ] + [row]
-                self.tbody.children = new_items
-
-        elif old_ids:
-            for old_id in old_ids:
-                row_to_remove = self.tbody.get_children(attr="layer_id", value=old_id)[
-                    0
-                ]
-                self.tbody.children = [
-                    row
-                    for row in self.tbody.children
-                    if row not in [row_to_remove, self.no_items]
-                ]
-
-        if not self.tbody.children:
-            self.tbody.children = [self.no_items]
-
-
-class CustomGeometryRow(sw.Html):
-    def __init__(self, map_, layer_id, **kwargs) -> None:
-        self.tag = "tr"
-        self.attributes = {"layer_id": layer_id}
-        self.layer_id = layer_id
-
-        super().__init__()
-
-        self.map_ = map_
-
-        # use layer_id to get the name of the geometry from the custom_layers dict
-        for layer in self.map_.custom_layers["features"]:
-            if layer["properties"]["id"] == layer_id:
-                name = layer["properties"]["name"]
-
-        # self.delete_btn = cw.TableIcon("fa-solid fa-trash-can", self.layer_id)
-        self.delete_btn = cw.TableIcon(icon("trash-can"), self.layer_id)
-
-        td_list = [
-            sw.Html(tag="td", children=[self.delete_btn]),
-            sw.Html(tag="td", children=[name]),
-        ]
-
-        super().__init__(tag="tr", children=td_list)
-
-        # add js behaviour
-        self.delete_btn.on_event("click", self.on_delete)
-
-    def on_delete(self, widget, data, event):
-        """Remove the line from the model and trigger table update."""
-        self.map_.remove_custom_layer(self.layer_id)

--- a/component/widget/custom_aoi_dialog.py
+++ b/component/widget/custom_aoi_dialog.py
@@ -4,12 +4,11 @@ from copy import deepcopy
 import ee
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_hex
-from component.frontend.icons import icon
 from sepal_ui import sepalwidgets as sw
 
 import component.parameter as cp
+from component.frontend.icons import icon
 from component.message import cm
-from component.widget import custom_widgets as cw
 from component.widget.base_dialog import BaseDialog
 from component.widget.buttons import TextBtn
 

--- a/component/widget/custom_aoi_dialog.py
+++ b/component/widget/custom_aoi_dialog.py
@@ -190,10 +190,12 @@ class CustomAoiDialog(BaseDialog):
     def on_cancel(self, *_):
         """Clear any in-progress drawing and remove the Geoman toolbar.
 
-        ``dc.clear()`` only resets the layer data; ``dc.hide()`` also pops
-        the toolbar off ``map_.controls`` so the user gets a clean map back
+        ``dc.clear()`` discards any draft features so they don't reappear
+        the next time the toolbar is shown; ``dc.hide()`` also pops the
+        toolbar off ``map_.controls`` so the user gets a clean map back
         after committing or cancelling the custom geometry.
         """
+        self.map_.dc.clear()
         self.map_.dc.hide()
 
         # Clear any feature that was selected

--- a/component/widget/custom_aoi_view.py
+++ b/component/widget/custom_aoi_view.py
@@ -1,9 +1,20 @@
+import logging
+
+from sepal_ui import mapping as sm
 from sepal_ui.aoi.aoi_view import AoiView
+from sepal_ui.message import ms
+
 from component.model.aoi_model import SeplanAoi
+
+logger = logging.getLogger("SEPLAN")
 
 
 class SeplanAoiView(AoiView):
-    def __init__(self, model: SeplanAoi, **kwargs: dict):
+    def __init__(self, model: SeplanAoi, app_model=None, **kwargs: dict):
+        # ``self.model`` will be the inner ``AoiModel`` after super().__init__,
+        # so stash the SeplanAoi wrapper for callbacks that need the
+        # LMIC traits (which live on the wrapper, not the inner model).
+        self.seplan_aoi = model
         kwargs.update(
             {
                 "methods": ["-POINTS"],
@@ -15,12 +26,156 @@ class SeplanAoiView(AoiView):
 
         super().__init__(**kwargs)
 
-        self.btn.small = True
+        # Stash app_model so the DRAW handler can close the MapApp dialog
+        # (``app_model.step_open = False`` propagates to ``MapApp.step_open``
+        # via the model binding, which the Vue watcher uses to close the
+        # active step dialog).
+        self._app_model = app_model
 
-        # self.children = [x for x in self.children if x != self.btn]
+        # Close the AOI dialog the moment the user picks DRAW so the map is
+        # uncovered for drawing. The submit step is auto-fired by the draw
+        # event handler below, so the user never needs to reopen the dialog.
+        if self.w_method is not None:
+            self.w_method.observe(self._maybe_close_dialog, "v_model")
+
+        # Reset the method dropdown every time a step dialog opens. Without
+        # this, picking DRAW once leaves ``w_method.v_model = "DRAW"`` after
+        # the auto-close; reopening the AOI dialog still shows DRAW, so the
+        # ``v_model`` observer doesn't fire again on a second pick. Resetting
+        # to ``None`` on each open guarantees the next pick is always a real
+        # change.
+        if app_model is not None:
+            app_model.observe(self._reset_method_on_open, "step_open")
+
+        # AoiView hardcodes the legacy ``sm.DrawControl`` for the DRAW method
+        # (pysepal/aoi/aoi_view.py:349). Swap it to Geoman so both draw flows
+        # (primary AOI here, sub-AOIs on SeplanMap.dc) use the same toolbar.
+        if self.map_ is not None and hasattr(sm, "GeomanDrawControl"):
+            if not isinstance(self.aoi_dc, sm.GeomanDrawControl):
+                if self.aoi_dc is not None:
+                    self.aoi_dc.hide()
+                self.aoi_dc = sm.GeomanDrawControl(self.map_)
+                self.aoi_dc.hide()
+            # Defensive: mirror Geoman create/remove events into ``self.data``.
+            # The JS view should sync via ``layers_to_data`` + ``save_changes``,
+            # but if the round-trip misfires, ``aoi_dc.to_json()`` would return
+            # an empty FeatureCollection and the AOI would silently stay empty.
+            self.aoi_dc.on_draw(self._mirror_draw_event)
+
+        self.btn.small = True
 
         model.observe(self.update_view, "set_map")
         model.observe(self.reset_view, "reset_view")
+
+        # Close the AOI step dialog automatically once the primary AOI is
+        # set AND the LMIC verdict is in. DRAW closes eagerly on method
+        # pick (see ``_maybe_close_dialog``); for ADMIN/ASSET/SHAPE we wait
+        # for the LMIC checker (custom_aoi_tile.AoiView) to bump
+        # ``aoi_lmic_checked``. If the AOI is outside LMIC, the dialog
+        # stays open so the user can read the warning before retrying.
+        model.observe(self._close_on_aoi_set, "aoi_lmic_checked")
+
+    def _close_on_aoi_set(self, change):
+        if not change.get("new") or self._app_model is None:
+            return
+        if not getattr(self.seplan_aoi, "aoi_lmic_valid", True):
+            return
+        self._app_model.step_open = False
+
+    def _mirror_draw_event(self, target, action, geo_json):
+        """Append created features into ``aoi_dc.data`` and schedule submit.
+
+        Geoman delivers ``geo_json`` as a list. We dedupe by geometry so the
+        explicit append stays idempotent against the JS-side ``layers_to_data``
+        sync. The submit step runs on the GEE event loop via
+        ``gee_interface.create_task`` so the Solara kernel thread stays
+        responsive while the polygon is converted into an AOI map layer.
+        """
+        if action != "create":
+            return
+        new_feats = geo_json if isinstance(geo_json, list) else [geo_json]
+        existing_geoms = [f.get("geometry") for f in self.aoi_dc.data]
+        appended = list(self.aoi_dc.data)
+        for feat in new_feats:
+            if feat.get("geometry") not in existing_geoms:
+                appended.append(feat)
+        if len(appended) != len(self.aoi_dc.data):
+            self.aoi_dc.data = appended
+
+        self._schedule_auto_submit()
+
+    def _schedule_auto_submit(self):
+        """Run the AOI submit on a GEE-loop background task (non-blocking).
+
+        Falls back to firing the validation button synchronously when no
+        ``gee_interface`` is available (e.g. ``gee=False`` testing path).
+        """
+        gee_interface = getattr(self.model, "gee_interface", None)
+        if not self.gee or gee_interface is None:
+            self.btn.fire_event("click", None)
+            return
+
+        task = gee_interface.create_task(
+            func=self._auto_submit_async,
+            key="aoi_auto_submit",
+            on_error=self._on_auto_submit_error,
+        )
+        # Hold a reference so the task isn't garbage-collected before it runs.
+        self._auto_submit_task = task
+        task.start()
+
+    async def _auto_submit_async(self):
+        """Async equivalent of pysepal's ``_update_aoi`` for the DRAW path.
+
+        Mirrors the work done by clicking the validation button, but uses
+        ``get_info_async`` / ``add_ee_layer_async`` so the GEE round-trips
+        don't block the kernel thread.
+        """
+        if self.aoi_dc is None:
+            return
+
+        self.model.geo_json = self.aoi_dc.to_json()
+        self.model.set_object()  # builds in-memory ee.FeatureCollection
+
+        if self.map_ is None:
+            self.updated += 1
+            return
+
+        fc = self.model.feature_collection
+        if fc is None:
+            return
+
+        gee_interface = self.model.gee_interface
+
+        # Bounds → zoom (async getInfo on the GEE loop).
+        coords = await gee_interface.get_info_async(
+            fc.geometry().bounds().coordinates().get(0)
+        )
+        bounds = [coords[0][0], coords[0][1], coords[2][0], coords[2][1]]
+
+        self.map_.remove_layer("aoi", none_ok=True)
+        self.map_.zoom_bounds(bounds)
+
+        # add_ee_layer_async resolves the slow getMapId off the kernel thread.
+        await self.map_.add_ee_layer_async(fc, {}, "aoi")
+
+        self.aoi_dc.hide()
+        self.alert.add_msg(ms.aoi_sel.complete, "success")
+        self.updated += 1
+
+    def _on_auto_submit_error(self, exc: Exception):
+        """Surface auto-submit failures via the AoiView alert area.
+
+        Also reopens the AOI step dialog: ``_maybe_close_dialog`` closes it
+        eagerly when the user picks DRAW so the map is uncovered, but if the
+        async submit fails (e.g. Geoman/JS sync race produced an empty
+        FeatureCollection) the user would otherwise be stranded with no
+        visible way back to the AOI selector.
+        """
+        logger.exception("AOI auto-submit failed", exc_info=exc)
+        self.alert.add_msg(str(exc), type_="error")
+        if self._app_model is not None:
+            self._app_model.step_open = True
 
     def update_view(self, *args):
         """Update the view when the feature collection is updated."""
@@ -31,3 +186,37 @@ class SeplanAoiView(AoiView):
         # I have to do this wrapper to avoid changing the sepal_ui model which
         # not receives any extra argument
         self.reset()
+
+    def _maybe_close_dialog(self, change):
+        """Close the AOI step dialog when the user picks DRAW.
+
+        ``app_model.step_open`` is bidirectionally linked to ``MapApp.step_open``,
+        so flipping it here triggers the Vue watcher in MapApp that closes the
+        active step dialog. The user can re-open the AOI drawer button to come
+        back if they want to change the method.
+        """
+        if change.get("new") == "DRAW" and self._app_model is not None:
+            self._app_model.step_open = False
+
+    def _reset_method_on_open(self, change):
+        """Clear the method dropdown when the user is starting a fresh AOI.
+
+        ``step_open`` toggles True for every dialog activation. Resetting
+        ``w_method.v_model`` is what enables the DRAW auto-close to fire
+        again on a second pick (the v_model observer needs an actual change
+        to trigger). However, the parent ``AoiView._activate`` reacts to
+        ``v_model -> None`` by also setting ``w_draw.v_model = None``, which
+        is bound to ``model.name`` — so a blind reset wipes the just-saved
+        AOI name and the recipe exports as ``N/A``. Gate on ``model.name``:
+        reset only when nothing has been validated yet.
+        """
+        # ``self.model`` is the ``SeplanAoi`` wrapper (no ``name`` trait);
+        # the actual AOI name lives on the inner ``aoi_model``. Reach
+        # through the wrapper so the gate isn't a no-op.
+        inner = getattr(self.seplan_aoi, "aoi_model", None)
+        if (
+            change.get("new")
+            and self.w_method is not None
+            and not getattr(inner, "name", None)
+        ):
+            self.w_method.v_model = None

--- a/component/widget/custom_geometries_dialog.py
+++ b/component/widget/custom_geometries_dialog.py
@@ -1,0 +1,201 @@
+"""Single entry-point dialog that consolidates all custom-geometry actions.
+
+Replaces the right-panel button stack with one "Custom geometries" button
+that opens a modal exposing Admin sub-area / Draw / Import as a compact
+list, alongside the table of existing custom geometries. Each list item
+dispatches via ``SeplanMap.on_draw`` (which closes this dialog before
+launching the chosen flow).
+"""
+
+import ipyvuetify as v
+import sepal_ui.sepalwidgets as sw
+
+import component.parameter as cp
+from component.frontend.icons import icon
+from component.message import cm
+from component.widget import custom_widgets as cw
+from component.widget.base_dialog import BaseDialog
+from component.widget.buttons import TextBtn
+
+
+class CustomGeometriesDialog(BaseDialog):
+    """Modal hub for managing custom sub-AOIs."""
+
+    def __init__(self, map_):
+        super().__init__()
+        self.attributes = {"id": "custom_geometries_dialog"}
+        self.map_ = map_
+
+        title = sw.CardTitle(children=["Custom geometries"])
+        description = sw.Html(
+            tag="p",
+            class_="ma-2 grey--text text--darken-1",
+            children=[
+                "Add sub-areas inside your primary AOI. Drawn or imported "
+                "shapes are checked against the primary AOI; admin sub-areas "
+                "are guaranteed to fit by hierarchy."
+            ],
+        )
+
+        # Compact list of actions. Each item carries an ``id`` attribute that
+        # ``SeplanMap.on_draw`` reads to dispatch (admin → AdminAoiDialog,
+        # new → Geoman on the map, import → ImportAoiDialog). Admin first
+        # because it's the recommended path for admin-based primaries.
+        self.item_admin = self._make_list_item("admin", "Admin sub-area")
+        self.item_new = self._make_list_item(
+            "new", cm.map.toolbar.draw_menu["new"]
+        )
+        self.item_import = self._make_list_item(
+            "import", cm.map.toolbar.draw_menu["import"]
+        )
+
+        actions_list = v.List(
+            dense=True,
+            class_="py-0",
+            children=[self.item_admin, self.item_new, self.item_import],
+        )
+
+        section_header = sw.Html(
+            tag="h4",
+            class_="ma-2 mt-4",
+            children=["Saved custom geometries"],
+        )
+        # Independent table instance — observes ``map_.custom_layers`` so it
+        # stays in sync without sharing state with ``CustomAoiDialog``.
+        self.table = CustomGeometriesTable(self.map_)
+
+        btn_close = TextBtn("Close", outlined=True)
+        btn_close.on_event("click", lambda *_: self.close_dialog())
+        action = sw.CardActions(children=[sw.Spacer(), btn_close])
+
+        text = sw.CardText(
+            children=[description, actions_list, section_header, self.table]
+        )
+        card = sw.Card(class_="ma-0", children=[title, text, action])
+        self.children = [card]
+
+    def _make_list_item(self, action_id: str, label: str) -> v.ListItem:
+        """Build a clickable list item that dispatches via ``map_.on_draw``."""
+        item = v.ListItem(
+            attributes={"id": action_id},
+            link=True,
+            ripple=True,
+            children=[
+                v.ListItemContent(
+                    children=[v.ListItemTitle(children=[label])]
+                ),
+            ],
+        )
+        item.on_event("click", self.map_.on_draw)
+        return item
+
+
+class CustomGeometriesTable(sw.Layout):
+    def __init__(self, map_) -> None:
+        self.class_ = "d-block"
+        self.attributes = {"id": "custom_geometries_table"}
+        self.no_items = cm.map.dialog.drawing.table.no_geometries
+
+        # create the table
+        super().__init__()
+
+        self.map_ = map_
+
+        # generate header using the translator
+        headers = sw.Html(
+            tag="tr",
+            children=[
+                sw.Html(tag="th", children=[title])
+                for title in cp.custom_geom_table_headers.values()
+            ],
+        )
+
+        self.tbody = sw.Html(attributes={"id": "tbody"}, tag="tbody", children=[])
+        self.set_rows()
+
+        # create the table
+        self.table = sw.SimpleTable(
+            dense=False,
+            children=[
+                sw.Html(tag="thead", children=[headers]),
+                self.tbody,
+            ],
+        )
+
+        self.children = [self.table]
+
+        # add js behavior
+        self.map_.observe(self.set_rows, "custom_layers")
+
+    def set_rows(self, *args):
+        """Add, remove or update rows in the table."""
+        # We don't want to recreate all the elements of the table each time since
+        # that's so expensive (specially the set_limits method)
+
+        view_layers = [
+            row.layer_id
+            for row in self.tbody.children
+            if isinstance(row, CustomGeometryRow)
+        ]
+        map_layers = [
+            lyr.get("properties")["id"] for lyr in self.map_.custom_layers["features"]
+        ]
+
+        new_ids = [id_ for id_ in map_layers if id_ not in view_layers]
+        old_ids = [id_ for id_ in view_layers if id_ not in map_layers]
+
+        if new_ids:
+            for new_id in new_ids:
+                row = CustomGeometryRow(self.map_, new_id)
+                # drop no items if it's in the table
+
+                new_items = [
+                    chld for chld in self.tbody.children if chld != self.no_items
+                ] + [row]
+                self.tbody.children = new_items
+
+        elif old_ids:
+            for old_id in old_ids:
+                row_to_remove = self.tbody.get_children(attr="layer_id", value=old_id)[
+                    0
+                ]
+                self.tbody.children = [
+                    row
+                    for row in self.tbody.children
+                    if row not in [row_to_remove, self.no_items]
+                ]
+
+        if not self.tbody.children:
+            self.tbody.children = [self.no_items]
+
+
+class CustomGeometryRow(sw.Html):
+    def __init__(self, map_, layer_id, **kwargs) -> None:
+        self.tag = "tr"
+        self.attributes = {"layer_id": layer_id}
+        self.layer_id = layer_id
+
+        super().__init__()
+
+        self.map_ = map_
+
+        # use layer_id to get the name of the geometry from the custom_layers dict
+        for layer in self.map_.custom_layers["features"]:
+            if layer["properties"]["id"] == layer_id:
+                name = layer["properties"]["name"]
+
+        self.delete_btn = cw.TableIcon(icon("trash-can"), self.layer_id)
+
+        td_list = [
+            sw.Html(tag="td", children=[self.delete_btn]),
+            sw.Html(tag="td", children=[name]),
+        ]
+
+        super().__init__(tag="tr", children=td_list)
+
+        # add js behaviour
+        self.delete_btn.on_event("click", self.on_delete)
+
+    def on_delete(self, widget, data, event):
+        """Remove the line from the model and trigger table update."""
+        self.map_.remove_custom_layer(self.layer_id)

--- a/component/widget/custom_geometries_dialog.py
+++ b/component/widget/custom_geometries_dialog.py
@@ -180,9 +180,11 @@ class CustomGeometryRow(sw.Html):
         self.map_ = map_
 
         # use layer_id to get the name of the geometry from the custom_layers dict
+        name = str(layer_id)
         for layer in self.map_.custom_layers["features"]:
             if layer["properties"]["id"] == layer_id:
                 name = layer["properties"]["name"]
+                break
 
         self.delete_btn = cw.TableIcon(icon("trash-can"), self.layer_id)
 

--- a/component/widget/import_aoi_dialog.py
+++ b/component/widget/import_aoi_dialog.py
@@ -34,14 +34,39 @@ class ImportAoiDialog(BaseDialog):
 
         self.children = [card]
 
+        # Caller-supplied dialog to restore on cancel — set per call to
+        # ``open_dialog(return_to=...)``. Cleared whenever it's consumed.
+        self._return_to = None
+
         # add js behavior
-        btn_cancel.on_event("click", lambda *_: self.close_dialog())
+        btn_cancel.on_event("click", lambda *_: self._cancel())
 
-        self.aoi_view.observe(lambda *_: self.close_dialog(), "updated")
+        # Successful import → close the dialog (next surface, the rename
+        # dialog, opens via CustomAoiDialog.on_new_geom from ImportAoiView).
+        # Also clear ``_return_to`` so a later cancel from a different open
+        # call doesn't bounce back to a stale picker.
+        self.aoi_view.observe(lambda *_: self._on_success(), "updated")
 
-    def open_dialog(self, *_):
-        """Reset AOI view and open the dialog."""
+    def _on_success(self):
+        self._return_to = None
+        self.close_dialog()
 
+    def _cancel(self, *_):
+        """Close and re-open the caller dialog if any."""
+        return_to = self._return_to
+        self._return_to = None
+        self.close_dialog()
+        if return_to is not None:
+            return_to.open_dialog()
+
+    def open_dialog(self, *_, return_to=None):
+        """Reset AOI view and open the dialog.
+
+        Args:
+            return_to: Optional dialog to re-open if the user cancels.
+        """
+        if return_to is not None:
+            self._return_to = return_to
         self.aoi_view.reset()
         super().open_dialog()
 
@@ -52,7 +77,10 @@ class ImportAoiView(AoiView):
 
     def __init__(self, custom_aoi_dialog, gee_interface, **kwargs):
 
-        methods = ["-POINTS"]
+        # Admin sub-areas have their own dedicated entry (AdminAoiDialog) —
+        # exclude ADMIN0/1/2 here to keep the import dialog focused on file
+        # uploads (SHAPE) and asset references (ASSET). POINTS is also off.
+        methods = ["-POINTS", "-ADMIN0", "-ADMIN1", "-ADMIN2"]
         self.elevation = False
 
         super().__init__(methods=methods, gee_interface=gee_interface, **kwargs)

--- a/component/widget/legend.py
+++ b/component/widget/legend.py
@@ -5,103 +5,16 @@ from typing import List, Literal
 import sepal_ui.sepalwidgets as sw
 from ipyleaflet import WidgetControl
 
-from component.message import cm
-
-
-def SuitabilityLegend() -> WidgetControl:
-    """Create a legend for the map.
-
-    Colors of the table will come from a css simple file located in fronted.
-    """
-    id_ = "".join(random.choices(string.ascii_letters, k=5))
-
-    style = sw.Html(
-        tag="style",
-        children=[
-            f"""
-            .legend_{id_} {{
-                height: 25px;
-                background-color: #353535;
-                background-image:
-                    linear-gradient(
-                    to right, 
-                    #353535,
-                    #353535 16.66%,
-                    #edf8fb 16.66%,
-                    #66c2a4,
-                    #006d2c
-                    );
-            }}
-
-            .td_title_{id_} {{
-                text-align:center !important;
-                font-size: 14px !important;
-                height: auto !important;
-            }}
-            .td_legend_{id_} {{
-                padding: 0px !important;
-                height: auto !important;
-            }}
-
-            .td_label_{id_} {{
-                width: 16.66%;
-                font-size: 12px !important;
-                line-height: 18px !important;
-                text-align:center !important;
-                height: auto !important;
-            }}
-            """
-        ],
-    )
-
-    title = sw.Html(
-        tag="td",
-        class_=f"td_title_{id_}",
-        attributes={"colspan": 6},
-        children=[sw.Html(tag="div", children="Restoration suitability index")],
-    )
-
-    legend_bar = sw.Html(
-        tag="td",
-        class_=f"td_legend_{id_}",
-        attributes={"colspan": 6},
-        children=[sw.Html(tag="div", class_=f"legend_{id_}")],
-    )
-
-    legend_names = {
-        "nodata": cm.map.legend.class_.nodata,
-        "vlow": cm.map.legend.class_.vlow,
-        "low": cm.map.legend.class_.low,
-        "medium": cm.map.legend.class_.medium,
-        "high": cm.map.legend.class_.high,
-        "vhigh": cm.map.legend.class_.vhigh,
-    }
-
-    legend_label = [
-        sw.Html(tag="td", class_=f"td_label_{id_}", children=[name])
-        for name in legend_names.values()
-    ]
-
-    legend = sw.SimpleTable(
-        style_="width:450px; background-color: transparent;",
-        class_="pa-0 ma-0",
-        children=[
-            style,
-            sw.Html(tag="tr", children=[title]),
-            sw.Html(tag="tr", children=[legend_bar]),
-            sw.Html(tag="tr", children=legend_label),
-        ],
-    )
-    # return legend
-
-    return WidgetControl(
-        widget=legend,
-        position="bottomright",
-        transparent_bg=True,
-    )
-
 
 class Legend(WidgetControl):
+    """Map legend widget styled to match the pysepal Solara legend overlay.
+
+    Kept as an ipyleaflet ``WidgetControl`` (rather than the Solara
+    ``LegendComponent``) because this legend lives inside dialog-bound maps
+    (e.g. ``PreviewMapDialog``) where a body-fixed Solara overlay would
+    render outside the dialog.
+    """
+
     def __init__(
         self,
         type_: Literal["stepped", "gradient"] = None,
@@ -109,37 +22,32 @@ class Legend(WidgetControl):
         names: List[str] = None,
         colors: List[str] = None,
     ):
-        """Create a legend for the map.
-
-        Args:
-            type_ (str): Type of the legend. Can be "stepped" or "gradient".
-            title (str): Title of the legend.
-            colors (list): Dictionary of colors.
-            names (list): List of names for the legend.
-        """
-        # create a random name for the legend
-        # this is needed to avoid having the same legend for different layers
         self.id_ = "".join(random.choices(string.ascii_letters, k=5))
 
-        self.title_row = sw.Html(tag="tr")
-        self.color_row = sw.Html(tag="tr")
-        self.label_row = sw.Html(tag="tr", class_=f"legend_tr_{self.id_}")
+        self.title_div = sw.Html(tag="div", class_=f"seplan-legend__title_{self.id_}")
+        self.bar_div = sw.Html(tag="div", class_=f"seplan-legend__bar_{self.id_}")
+        self.labels_div = sw.Html(
+            tag="div", class_=f"seplan-legend__labels_{self.id_}"
+        )
 
         self.style = sw.Html(tag="style")
 
-        legend = sw.SimpleTable(
-            style_="width:450px; background-color: transparent;",
-            class_="pa-0 ma-0",
-            children=[self.style, self.title_row, self.color_row, self.label_row],
+        # The wrapper class lets us target the surrounding ``.leaflet-control``
+        # via a parent selector, so even if Leaflet's default float is
+        # overridden somewhere, we can force the legend back to the right.
+        body = sw.Html(
+            tag="div",
+            class_=(
+                f"seplan-legend seplan-legend_{self.id_} "
+                f"seplan-legend-anchor-{self.id_}"
+            ),
+            children=[self.style, self.title_div, self.bar_div, self.labels_div],
         )
 
-        control_args = {}
-        control_args["widget"] = legend
-        control_args["position"] = "bottomright"
-        control_args["transparent_bg"] = True
-        control_args["attributes"] = {"id": "legend"}
-
-        super().__init__(**control_args)
+        super().__init__(
+            widget=body,
+            position="bottomright",
+        )
 
         if all([type_, title, names, colors]):
             self.update_legend(type_, title, names, colors)
@@ -152,85 +60,73 @@ class Legend(WidgetControl):
         colors: List[str],
     ):
         names = [str(name) for name in names]
-        gradient = get_color_css(type_, colors)
+        gradient_css = get_color_css(type_, colors)
+
+        # Justify labels: 2 stops → space-between, 3+ → evenly spaced.
+        justify = "space-between" if len(names) <= 3 else "space-around"
 
         style = f"""
-            .legend_{self.id_} {{
-                height: 20px;
-                background-color: #353535;
-                {gradient}
-            }}
+        .seplan-legend_{self.id_} {{
+            font-family: Roboto, sans-serif;
+            background: rgba(33, 33, 33, 0.85);
+            color: #fff;
+            backdrop-filter: blur(4px);
+            -webkit-backdrop-filter: blur(4px);
+            border-radius: 8px;
+            padding: 8px 14px;
+            font-size: 12px;
+            display: inline-flex;
+            flex-direction: column;
+            gap: 4px;
+            width: fit-content;
+            min-width: 220px;
+            max-width: 90vw;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+        }}
 
-            .td_title_{self.id_} {{
-                text-align:center !important;
-                font-size: 14px !important;
-                height: auto !important;
-            }}
+        .seplan-legend__title_{self.id_} {{
+            font-size: 11px;
+            opacity: 0.85;
+            text-align: center;
+            line-height: 1.2;
+        }}
 
-            .td_legend_{self.id_} {{
-                padding: 0px !important;
-                height: auto !important;
-            }}
+        .seplan-legend__bar_{self.id_} {{
+            height: 12px;
+            border-radius: 3px;
+            min-width: 200px;
+            {gradient_css}
+        }}
 
-            .td_label_{self.id_} {{
-                width: {100/len(names)}%;
-                font-size: 12px !important;
-                line-height: 18px !important;
-                text-align:center !important;
-                height: auto !important;
-                padding: 0px !important;
-            }}
-           
+        .seplan-legend__labels_{self.id_} {{
+            display: flex;
+            justify-content: {justify};
+            font-size: 11px;
+            opacity: 0.85;
+            line-height: 1.2;
+        }}
+
+        .seplan-legend__labels_{self.id_} > span {{
+            white-space: nowrap;
+        }}
         """
 
-        if len(names) <= 3:
-            style += f"""
-            .legend_tr_{self.id_} > td:first-child {{
-                text-align: left !important;
-            }}
-
-            .legend_tr_{self.id_} > td:last-child {{
-                text-align: right !important;
-            }}
-            """
-
-        self.title_row.children = [
-            sw.Html(
-                tag="td",
-                class_=f"td_title_{self.id_}",
-                attributes={"colspan": len(names)},
-                children=[sw.Html(tag="div", children=title)],
-            )
+        self.title_div.children = [title]
+        self.bar_div.children = []
+        self.labels_div.children = [
+            sw.Html(tag="span", children=[name]) for name in names
         ]
-
-        self.color_row.children = [
-            sw.Html(
-                tag="td",
-                class_=f"td_legend_{self.id_}",
-                attributes={"colspan": len(names)},
-                children=[sw.Html(tag="div", class_=f"legend_{self.id_}")],
-            )
-        ]
-
-        self.label_row.children = [
-            sw.Html(tag="td", class_=f"td_label_{self.id_}", children=[name])
-            for name in names
-        ]
-
         self.style.children = [style]
 
 
 def get_color_css(type_, colors):
-    """Generates a CSS linear-gradient from a list of colors.
+    """Generate a CSS background gradient for the legend bar.
 
-    Parameters:
-    - colors: list of strings representing CSS colors.
-
-    Returns:
-    - CSS string with linear-gradient.
+    ``gradient`` produces a smooth linear gradient; ``stepped`` produces
+    discrete color blocks of equal width.
     """
     if type_ == "gradient":
-        return f"background: linear-gradient(to right, {', '.join(colors)})"
+        return f"background: linear-gradient(to right, {', '.join(colors)});"
 
     if not colors:
         return ""
@@ -245,12 +141,9 @@ def get_color_css(type_, colors):
     for i, color in enumerate(colors):
         start = i * percentage
         end = (i + 1) * percentage
-        if i == num_colors - 1:  # For the d color
+        if i == num_colors - 1:
             segments.append(f"{color} {start:.2f}%")
         else:
             segments.append(f"{color} {start:.2f}% {end:.2f}%")
 
-    gradient = ", ".join(segments)
-    css = f"background: linear-gradient(to right, {gradient});"
-
-    return css
+    return f"background: linear-gradient(to right, {', '.join(segments)});"

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,23 +1,25 @@
+import time
 from copy import deepcopy
 from typing import Optional
 
 import ipyvuetify as v
 from component.frontend.icons import icon
-from component.widget.buttons import IconBtn
-from component.widget.custom_widgets import DrawMenu
+from component.widget.buttons import IconBtn, TextBtn
 import sepal_ui.sepalwidgets as sw
 from ipyleaflet import GeoJSON, WidgetControl, basemap_to_tiles, basemaps
+from shapely.geometry import Point, shape
 from sepal_ui import mapping as sm
 from traitlets import Dict, Int, link
 from sepal_ui.scripts.gee_interface import GEEInterface
 from sepal_ui import color
 from sepal_ui.mapping.map_btn import MapBtn
-
+from component.widget.admin_aoi_dialog import AdminAoiDialog
+from component.widget.custom_geometries_dialog import CustomGeometriesDialog
 from component.message import cm
 from component import widget as cw
 
 from component.model.aoi_model import SeplanAoi
-from component.widget.legend import SuitabilityLegend
+from component.widget.admin_aoi_dialog import _is_admin_eligible
 from ipyleaflet import SplitMapControl
 
 
@@ -53,10 +55,13 @@ class SeplanMap(sm.SepalMap):
         self.add_basemap("SATELLITE")
         self.dc.hide()
 
-        self.btn_draw = DrawMenu(
-            gliph="fa-solid fa-draw-polygon",
-            icon=True,
-            small=True,
+        # Single right-panel entry point that opens the consolidated modal.
+        # The actual Admin / Draw / Import items live inside that modal as
+        # list items (see ``custom_geometries_dialog.CustomGeometriesDialog``).
+        self.btn_custom_geom = TextBtn(
+            "Custom geometries",
+            block=True,
+            disabled=True,
         )
 
         self.btn_clean = MapBtn(icon("broom"))
@@ -66,56 +71,122 @@ class SeplanMap(sm.SepalMap):
             self.custom_aoi_dialog, gee_interface=self.gee_interface
         )
 
-        self.add(SuitabilityLegend())
+        self.admin_aoi_dialog = AdminAoiDialog(
+            custom_aoi_dialog=self.custom_aoi_dialog,
+            gee_interface=self.gee_interface,
+            map_=self,
+        )
+        self.custom_geometries_dialog = CustomGeometriesDialog(self)
+
+        # The suitability legend is now mounted as a Solara overlay in Page()
+        # via component.widget.seplan_legend.SuitabilityLegendOverlay.
 
         # create a window to display AOI information
         self.html = sw.Html(tag="h3", style_="margin:0em 2em 0em 2em;")
         control = WidgetControl(widget=self.html, position="bottomright")
         self.add(control)
 
-        self.add(WidgetControl(widget=self.btn_draw, position="topleft"))
+        # btn_custom_geom lives in the right panel and opens
+        # ``custom_geometries_dialog``, which renders the action list items
+        # and the saved-geometries table.
         self.add(WidgetControl(widget=self.btn_clean, position="topright"))
         self.add(WidgetControl(widget=self.custom_aoi_dialog, position="topright"))
         self.add(WidgetControl(widget=self.import_aoi_dialog, position="topright"))
+        self.add(WidgetControl(widget=self.admin_aoi_dialog, position="topright"))
+        self.add(
+            WidgetControl(widget=self.custom_geometries_dialog, position="topright")
+        )
+
+        # Cached (minx, miny, maxx, maxy, shapely_geom) per custom layer for
+        # the cheap hover-leave detection — rebuilt only when ``custom_layers``
+        # changes (not on every mousemove).
+        self._hover_bbox_cache: list = []
+        self._hover_check_last: float = 0.0
 
         self.dc.on_draw(self._handle_draw)
         self.observe(self.on_custom_layers, "custom_layers")
+        self.on_interaction(self._on_map_interaction)
 
         # It has to be two way, so we can load the data by just updating the model
         link((self, "custom_layers"), (self.aoi_model, "custom_layers"))
 
         self.aoi_model.observe(self.reset, "reset_view")
 
-        self.btn_draw.on_event("new", self.on_draw)
-        self.btn_draw.on_event("show", self.on_draw)
-        self.btn_draw.on_event("import", self.on_draw)
+        # Click dispatch on the modal's list items is wired inside
+        # ``CustomGeometriesDialog._make_list_item`` (each item registers
+        # ``self.map_.on_draw`` as its click handler).
         self.btn_clean.on_event("click", self.clean_map)
+        self.btn_custom_geom.on_event(
+            "click", lambda *_: self.custom_geometries_dialog.open_dialog()
+        )
+
+        # Enable the entry button + modal items only once a primary AOI exists.
+        self._sync_custom_geom_buttons()
+        self.aoi_model.observe(self._sync_custom_geom_buttons, "feature_collection")
+        # Admin sub-area also depends on the primary AOI's method, which only
+        # changes via the inner ``aoi_model`` (e.g. ``ADMIN0`` → ``DRAW``).
+        self.aoi_model.aoi_model.observe(self._sync_custom_geom_buttons, "method")
+
+    def _sync_custom_geom_buttons(self, *_):
+        """Toggle the entry button + modal list items based on the primary AOI.
+
+        Sub-AOIs only make sense relative to a defined primary AOI, so the
+        ``Custom geometries`` entry button and the Draw / Import items inside
+        its modal stay disabled until ``seplan_aoi.feature_collection`` is set.
+        The Admin sub-area item has an extra constraint: it only makes sense
+        when the primary AOI is admin-based (``ADMIN0`` or ``ADMIN1``);
+        ``ADMIN2`` is the finest grain so no further subdivision is offered,
+        and non-admin primaries (DRAW / SHAPE / ASSET) skip it.
+        """
+
+        has_aoi = self.aoi_model.feature_collection is not None
+        primary_method = getattr(self.aoi_model.aoi_model, "method", "") or ""
+        admin_eligible = has_aoi and _is_admin_eligible(primary_method)
+
+        self.btn_custom_geom.disabled = not has_aoi
+
+        dialog = getattr(self, "custom_geometries_dialog", None)
+        if dialog is not None:
+            dialog.item_new.disabled = not has_aoi
+            dialog.item_import.disabled = not has_aoi
+            dialog.item_admin.disabled = not admin_eligible
 
     def on_draw(self, widget, event, data):
-        """Show or hide drawing control on the map."""
+        """Dispatch list-item clicks from the Custom Geometries modal.
+
+        Closes the picker first so the user lands directly on the chosen
+        surface. For Import / Admin we also pass ``return_to`` so a Cancel
+        click in those dialogs walks the user back to the picker rather
+        than dropping them on the bare map.
+        """
+        self.custom_geometries_dialog.close_dialog()
 
         if widget.attributes["id"] == "new":
-            if not self.aoi_tools:
-                widget.style_ = f"background-color: {color.menu};"
-                self.dc.show()
-            else:
-                widget.style_ = f"background-color: {color.main};"
-                self.dc.hide()
-
-            self.aoi_tools = not self.aoi_tools
+            self.dc.show()
 
         elif widget.attributes["id"] == "import":
             self.dc.hide()
-            self.import_aoi_dialog.open_dialog()
+            self.import_aoi_dialog.open_dialog(return_to=self.custom_geometries_dialog)
 
-        elif widget.attributes["id"] == "show":
+        elif widget.attributes["id"] == "admin":
             self.dc.hide()
-            self.custom_aoi_dialog.open_dialog(new_geom=False)
+            self.admin_aoi_dialog.open_dialog(return_to=self.custom_geometries_dialog)
 
-    def clean_map(self, keep_aoi: bool = True, *args):
-        """Remove control for split and all layers"""
+    def clean_map(self, *args, keep_aoi: bool = True):
+        """Remove computed result layers but keep the AOI and user geometries.
 
-        self.remove_all(keep_names=["aoi"] if keep_aoi else [])
+        Custom sub-AOIs the user drew or imported live in
+        ``self.custom_layers``; their on-map ipyleaflet ``GeoJSON`` layers
+        carry the user's chosen names. We preserve those by name so that
+        re-running compute / compare-scenarios doesn't wipe them.
+        """
+        keep = ["aoi"] if keep_aoi else []
+        keep += [
+            feat["properties"]["name"]
+            for feat in self.custom_layers["features"]
+            if feat.get("properties", {}).get("name")
+        ]
+        self.remove_all(keep_names=keep)
         self.controls = [
             control
             for control in self.controls
@@ -154,6 +225,18 @@ class SeplanMap(sm.SepalMap):
             ]:
                 self.remove_layer(layer)
 
+        # Refresh the cached bbox / shapely geoms used by the hover-leave
+        # detector. Built once here, not on every mousemove.
+        cache = []
+        for feat in self.custom_layers["features"]:
+            geom_dict = feat.get("geometry")
+            if not geom_dict:
+                continue
+            geom = shape(geom_dict)
+            minx, miny, maxx, maxy = geom.bounds
+            cache.append((minx, miny, maxx, maxy, geom))
+        self._hover_bbox_cache = cache
+
     def remove_custom_layer(self, layer_id):
         """Remove custom layer from the custom_layers dict."""
         # Create a copy of the current custom_layers dict
@@ -168,24 +251,57 @@ class SeplanMap(sm.SepalMap):
                 self.custom_layers = current_feats
 
     def _handle_draw(self, target, action, geo_json):
-        """handle the draw on map event."""
-        # polygonize circles
-        if "radius" in geo_json["properties"]["style"]:
-            geo_json = self.to_json()
+        """handle the draw on map event.
 
-        if action == "created":
+        Accepts both action conventions — legacy ipl.DrawControl emits
+        ``created``/``deleted``/``edited`` with ``geo_json`` as a single
+        feature dict; Geoman emits ``create``/``remove``/``edit``/``cut``/
+        ``rotate``/``vertexadded`` with ``geo_json`` as a list of features.
+        We don't read ``geo_json`` here, so the shape difference is
+        invisible at this layer. Polygonization happens at save time via
+        ``self.dc.to_json()``.
+        """
+        if action in ("create", "created"):
             # custom_aoi_dialog will be listening to this trait
             self.new_geom += 1
             self.aoi_model.updated += 1
 
-        elif action == "deleted":
-            current_feats = deepcopy(self.custom_layers)
-            for feat in current_feats["features"]:
-                if feat["geometry"] == geo_json["geometry"]:
-                    current_feats["features"].remove(feat)
+    def _on_map_interaction(self, **kwargs):
+        """Clear the hover label when the cursor isn't over a custom layer.
 
-                    # Trigger the change in the custom_layers dict
-                    self.custom_layers = current_feats
+        Mousemove fires constantly, so this runs on a multi-user server —
+        we keep it cheap with three gates:
+
+        1. ``self.html.children`` is empty → return immediately (no label
+           to clear). This is the common case: the label only exists for
+           a few seconds after a hover.
+        2. Throttle to ~10 Hz via ``_hover_check_last``.
+        3. Bounding-box quick-reject against the cached
+           ``_hover_bbox_cache`` before paying for ``shapely.contains``.
+
+        ``mouseout`` would be the natural signal but ipyleaflet's GeoJSON
+        only registers ``mouseover``/``click`` on the JS side
+        (``onEachFeature`` in jupyter-leaflet's index.js), so the comm
+        never sees it.
+        """
+        if not self.html.children:
+            return
+        if kwargs.get("type") != "mousemove":
+            return
+        now = time.monotonic()
+        if now - self._hover_check_last < 0.1:
+            return
+        self._hover_check_last = now
+        coords = kwargs.get("coordinates")
+        if not coords:
+            return
+        # Leaflet gives ``[lat, lng]``; shapely uses ``(x=lng, y=lat)``.
+        x, y = coords[1], coords[0]
+        for minx, miny, maxx, maxy, geom in self._hover_bbox_cache:
+            if minx <= x <= maxx and miny <= y <= maxy:
+                if geom.contains(Point(x, y)):
+                    return
+        self.html.children = []
 
     def _display_name(self, feature, **kwargs):
         """update the AOI in the html viewver widget."""

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,17 +1,14 @@
 import time
 from copy import deepcopy
-from typing import Optional
 
-import ipyvuetify as v
 from component.frontend.icons import icon
-from component.widget.buttons import IconBtn, TextBtn
+from component.widget.buttons import TextBtn
 import sepal_ui.sepalwidgets as sw
-from ipyleaflet import GeoJSON, WidgetControl, basemap_to_tiles, basemaps
+from ipyleaflet import GeoJSON, WidgetControl
 from shapely.geometry import Point, shape
 from sepal_ui import mapping as sm
 from traitlets import Dict, Int, link
 from sepal_ui.scripts.gee_interface import GEEInterface
-from sepal_ui import color
 from sepal_ui.mapping.map_btn import MapBtn
 from component.widget.admin_aoi_dialog import AdminAoiDialog
 from component.widget.custom_geometries_dialog import CustomGeometriesDialog

--- a/component/widget/recipe_header.py
+++ b/component/widget/recipe_header.py
@@ -1,0 +1,127 @@
+"""Right-panel header showing the current recipe name and a Save button.
+
+Renders compact: "<recipe-name> • saved/unsaved" with a save icon button to
+the right. Observes ``recipe.recipe_session_path`` and ``recipe.new_changes``
+so the label and dirty state stay in sync without manual wiring from
+callers.
+"""
+
+from pathlib import Path
+
+import sepal_ui.sepalwidgets as sw
+from sepal_ui.scripts import utils as su
+
+from component.frontend.icons import icon
+from component.message import cm
+from component.model.recipe import Recipe
+from component.scripts import validation
+from component.widget.alert_state import Alert
+from component.widget.buttons import IconBtn
+from component.widget.custom_widgets import RecipeInspector
+
+
+class RecipeHeader(sw.Layout):
+    """Pinned header: recipe name + saved/unsaved indicator + Save button."""
+
+    def __init__(self, recipe: Recipe, alert: Alert, **kwargs):
+        self.class_ = "d-flex align-center pa-2"
+        self.attributes = {"id": "recipe_header"}
+        super().__init__(**kwargs)
+
+        self.recipe = recipe
+        self.alert = alert
+
+        self.name_field = sw.TextField(
+            v_model=self._format_name(),
+            dense=True,
+            hint=self._format_status(),
+            persistent_hint=True,
+            class_="mr-2 flex-grow-1",
+        )
+        self.btn_view = IconBtn(gliph="mdi-eye")
+        self.btn_view.attributes = {"id": "btn_recipe_header_view"}
+        self.btn_save = IconBtn(gliph=icon("save"))
+        self.btn_save.attributes = {"id": "btn_recipe_header_save"}
+
+        self.inspector = RecipeInspector()
+
+        self.children = [
+            self.name_field,
+            self.btn_save,
+            self.btn_view,
+            self.inspector,
+        ]
+
+        self.recipe.observe(self._on_path_change, "recipe_session_path")
+        self.recipe.observe(self._on_changes, "new_changes")
+        self.btn_view.on_event("click", self._on_view)
+        self.btn_save.on_event("click", self._on_save)
+        self.name_field.on_event("blur", self._commit_name)
+        self.name_field.on_event("keydown.enter", self._commit_name)
+
+    def _format_name(self) -> str:
+        if not self.recipe.recipe_session_path:
+            return "No recipe"
+        return Path(self.recipe.recipe_session_path).stem
+
+    def _format_status(self) -> str:
+        if not self.recipe.recipe_session_path:
+            return ""
+        return "unsaved" if self.recipe.new_changes else "saved"
+
+    def _on_path_change(self, _):
+        self.name_field.v_model = self._format_name()
+        self.name_field.hint = self._format_status()
+
+    def _on_changes(self, _):
+        self.name_field.hint = self._format_status()
+
+    def _build_recipe_dict(self) -> dict:
+        """Snapshot of the live recipe in the same shape ``Recipe.save`` writes.
+
+        Built directly from the in-memory models so the inspector can render
+        unsaved changes — never reads from disk.
+        """
+        data = {
+            "signature": "live-session",
+            "aoi": self.recipe.seplan_aoi.export_data(),
+            "benefits": self.recipe.benefit_model.export_data(),
+            "constraints": self.recipe.constraint_model.export_data(),
+            "costs": self.recipe.cost_model.export_data(),
+        }
+        for key in ("updated", "new_changes", "object_set"):
+            validation.remove_key(data, key)
+        return data
+
+    def _commit_name(self, widget, event, data):
+        """Normalize the typed name and rewrite ``recipe_session_path``.
+
+        Only changes the in-memory path; the file isn't created/renamed
+        until the user clicks Save. Empty/unchanged input is ignored and
+        the field is restored to the canonical name.
+        """
+        new_name = (widget.v_model or "").strip()
+        if new_name:
+            new_name = su.normalize_str(new_name)
+        current = self._format_name()
+        if new_name and new_name != current:
+            self.recipe.recipe_session_path = self.recipe.get_recipe_path(new_name)
+        else:
+            self.name_field.v_model = current
+
+    def _on_view(self, *_):
+        name = self._format_name()
+        self.inspector.set_data(self._build_recipe_dict(), recipe_name=name)
+
+    def _on_save(self, *_):
+        path = self.recipe.recipe_session_path
+        if not path:
+            self.alert.add_msg(cm.recipe.error.no_name, type_="warning")
+            return
+        try:
+            self.recipe.save(path)
+            self.alert.add_msg(
+                cm.recipe.states.save.format(path), type_="success"
+            )
+        except Exception as exc:
+            self.alert.add_msg(str(exc), type_="error")

--- a/component/widget/scenarios_dialog.py
+++ b/component/widget/scenarios_dialog.py
@@ -166,6 +166,7 @@ class CompareScenariosDialog(BaseDialog):
 
         layer_control = SplitMapControl(left_layer=layers[0], right_layer=layers[1])
         map_.add(layer_control)
+
         self.close_dialog()
 
     def _configure_statistics_comparison(self):

--- a/component/widget/seplan_legend.py
+++ b/component/widget/seplan_legend.py
@@ -1,0 +1,68 @@
+"""Solara legend overlay for SEPLAN's main map.
+
+Mounts pysepal's body-level ``LegendComponent`` so the suitability legend
+sits as a floating overlay aware of MapApp's drawer and right-panel offsets,
+replacing the legacy ipyleaflet ``WidgetControl``-based ``SuitabilityLegend``.
+"""
+
+from dataclasses import asdict
+from typing import Optional
+
+import solara
+from pysepal.solara.components.legend import (
+    DiscreteEntry,
+    GradientEntry,
+    LegendComponent,
+    LegendData,
+)
+
+from component.message import cm
+
+
+def suitability_legend() -> LegendData:
+    """Canonical legend data for the restoration suitability index."""
+    return LegendData(
+        gradients=[
+            GradientEntry(
+                colors=["#edf8fb", "#66c2a4", "#006d2c"],
+                labels=[
+                    cm.map.legend.class_.vlow,
+                    cm.map.legend.class_.low,
+                    cm.map.legend.class_.medium,
+                    cm.map.legend.class_.high,
+                    cm.map.legend.class_.vhigh,
+                ],
+                title=cm.map.legend.title,
+            ),
+        ],
+        items=[DiscreteEntry(label=cm.map.legend.class_.nodata, color="#353535")],
+    )
+
+
+_HIDE_WHEN_DIALOG_CSS = """
+/* pysepal toggles body.sepal-modal-open only for MapApp step dialogs.
+   se.plan also opens many ad-hoc ipyvuetify v-dialogs (custom AOI,
+   scenarios, import, etc.) — :has() lets us hide the legend while ANY
+   Vuetify dialog overlay is mounted in the document. */
+body:has(.v-dialog__content--active) .sepal-legend,
+body:has(.v-overlay--active) .sepal-legend {
+    display: none !important;
+}
+"""
+
+
+@solara.component
+def SuitabilityLegendOverlay():
+    """Floating suitability-index legend over the main map.
+
+    Always rendered, starts collapsed (icon pill). The user expands /
+    re-collapses via the pill click; ``LegendComponent`` keeps that toggle
+    in its own Vue state, so no Python reactive is needed and the parent
+    Page doesn't re-render on toggle.
+    """
+    solara.Style(_HIDE_WHEN_DIALOG_CSS)
+    LegendComponent(
+        legend_data=asdict(suitability_legend()),
+        visible=True,
+        collapsed=True,
+    )

--- a/component/widget/seplan_legend.py
+++ b/component/widget/seplan_legend.py
@@ -6,7 +6,6 @@ replacing the legacy ipyleaflet ``WidgetControl``-based ``SuitabilityLegend``.
 """
 
 from dataclasses import asdict
-from typing import Optional
 
 import solara
 from pysepal.solara.components.legend import (

--- a/component/widget/suitability_table.py
+++ b/component/widget/suitability_table.py
@@ -15,11 +15,13 @@ def get_table_table_body(
     suitability_levels,
     display_type: Literal["absolute", "percentage", "both"] = "both",
 ):
-    # Collect all area names across all recipes
+    # Collect all area names across all recipes. Drop ``None`` keys (legacy
+    # recipes occasionally carry a custom layer with no ``name``) so the
+    # sort below doesn't blow up on ``str < NoneType``.
     areas = set()
     for recipe_stats_dict in recipe_stats_list:
         for summary_stats in recipe_stats_dict.values():
-            areas.update(summary_stats.keys())
+            areas.update(k for k in summary_stats.keys() if k is not None)
     areas = sorted(areas)
 
     # Determine if we need to include the recipe name column

--- a/component/widget/vue/dialog.vue
+++ b/component/widget/vue/dialog.vue
@@ -1,9 +1,7 @@
 <!-- Custom dialog to trigger a resize event when it is open -->
 <template>
     <v-dialog v-model="show" :persistent="persistent" :max-width="max_width" :min-width="min_width" :retain-focus="retain_focus">
-          <template v-for="(child, index) in children" :key="index">
-            <jupyter-widget :widget="child"></jupyter-widget>
-          </template>
+          <jupyter-widget v-for="(child, index) in children" :key="index" :widget="child"></jupyter-widget>
     </v-dialog>
   </template>
   

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,6 +3,6 @@ services:
     ports:
       - "8765:8765"
     extra_hosts:
-      - 'host.docker.internal:host-gateway'
+      - "${SEPAL_HOST:?SEPAL_HOST must be set}:host-gateway"
     environment:
-      SEPAL_HOST: "host.docker.internal"
+      SEPAL_HOST: ${SEPAL_HOST}

--- a/logging_config.toml
+++ b/logging_config.toml
@@ -1,0 +1,85 @@
+version = 1
+disable_existing_loggers = false
+
+# ─── FORMATTERS ──────────────────────────────────────────────
+[formatters.colored_seplan]
+"()"      = "colorlog.ColoredFormatter"
+format    = "%(log_color)s%(asctime)s - \u001b[44m%(name)s\u001b[0m - %(levelname)s - %(message)s"
+datefmt   = "%Y-%m-%d %H:%M:%S"
+[formatters.colored_seplan.log_colors]
+DEBUG     = "cyan"
+INFO      = "green"
+WARNING   = "yellow"
+ERROR     = "red"
+CRITICAL  = "bold_red"
+
+[formatters.colored_ee]
+"()"      = "colorlog.ColoredFormatter"
+format    = "%(log_color)s%(asctime)s - \u001b[45m%(name)s\u001b[0m - %(levelname)s - %(message)s"
+datefmt   = "%Y-%m-%d %H:%M:%S"
+[formatters.colored_ee.log_colors]
+DEBUG     = "cyan"
+INFO      = "white"
+WARNING   = "yellow"
+ERROR     = "red"
+CRITICAL  = "bold_red"
+
+
+# ─── HANDLERS ────────────────────────────────────────────────
+
+[handlers.console]
+class     = "logging.StreamHandler"
+level     = "DEBUG"
+stream    = "ext://sys.stdout"
+
+[handlers.seplan_console]
+class     = "logging.StreamHandler"
+formatter = "colored_seplan"
+stream    = "ext://sys.stdout"
+
+[handlers.ee_console]
+class     = "logging.StreamHandler"
+formatter = "colored_ee"
+stream    = "ext://sys.stdout"
+
+# ─── LOGGERS ────────────────────────────────────────────────
+
+[loggers.SEPLAN]
+level     = "DEBUG"
+handlers  = ["seplan_console"]
+propagate = false
+
+[loggers.eeclient]
+level     = "WARNING"
+handlers  = ["ee_console"]
+propagate = false
+
+[loggers.EECLIENT]
+level     = "WARNING"
+handlers  = ["ee_console"]
+propagate = false
+
+[loggers.solara]
+level     = "DEBUG"
+handlers  = ["seplan_console"]
+propagate = false
+
+[loggers.sepalui]
+level     = "DEBUG"
+handlers  = ["seplan_console"]
+propagate = false
+
+[loggers.httpx]
+level     = "INFO"
+handlers  = ["console"]
+propagate = false
+
+[loggers."numexpr.utils"]
+level     = "WARNING"
+handlers  = ["console"]
+propagate = false
+
+# ─── ROOT ───────────────────────────────────────────────────
+[root]
+level    = "INFO"
+handlers = ["console"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ toml
 ipecharts>=1.2.0
 rasterio<1.3.11 # Leave it here even if it's already in the sepal_ui requirements. Check https://github.com/openforis/sepal/issues/328
 
-sepal_ui==3.1.1
+pysepal>=3.5.0
 
 https://github.com/dfguerrerom/ipyleaflet/raw/refs/heads/master/wheels/jupyter_leaflet-0.20.0-py3-none-any.whl
 https://github.com/dfguerrerom/ipyleaflet/raw/refs/heads/master/wheels/ipyleaflet-0.20.0-py3-none-any.whl

--- a/solara_app.py
+++ b/solara_app.py
@@ -80,7 +80,9 @@ def Page():
     recipe_tile = RecipeView(
         recipe=recipe, app_model=app_model, sepal_session=sepal_client
     )
-    aoi_view = AoiView(map_, gee_interface=gee_interface, recipe=recipe)
+    aoi_view = AoiView(
+        map_, gee_interface=gee_interface, recipe=recipe, app_model=app_model
+    )
 
     questionnaire_tile = QuestionnaireTile(
         gee_interface=gee_interface,
@@ -162,6 +164,8 @@ def Page():
         dialog_width=860,
         right_panel_config=right_panel_config,
         right_panel_content=right_panel_content,
+        right_panel_open=True,
         repo_url="https://github.com/sepal-contrib/se.plan",
         docs_url="https://docs.sepal.io/en/latest/modules/dwn/seplan.html",
+        model=app_model,
     )

--- a/solara_app.py
+++ b/solara_app.py
@@ -27,6 +27,7 @@ from component.frontend.icons import icon
 from component.model.recipe import Recipe
 from component.tile.custom_aoi_tile import AoiView
 from component.widget.map import SeplanMap
+from component.widget.seplan_legend import SuitabilityLegendOverlay
 from component.tile.questionnaire_tile import QuestionnaireTile
 from component.tile.recipe_tile import RecipeView
 from component.tile.right_panel import get_right_panel_content
@@ -169,3 +170,5 @@ def Page():
         docs_url="https://docs.sepal.io/en/latest/modules/dwn/seplan.html",
         model=app_model,
     )
+
+    SuitabilityLegendOverlay()

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -1,0 +1,314 @@
+"""Tests for the dashboard CSV export (`component.scripts.compute.export_as_csv`)."""
+
+import copy
+import re
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+EXPECTED_COLUMNS = [
+    "Recipe",
+    "Area",
+    "AOI type",
+    "Theme",
+    "Indicator",
+    "Unit",
+    "Aggregation",
+    "Value",
+]
+
+
+@pytest.fixture
+def single_aoi_stats():
+    """A RecipeStatsDict with one primary AOI and the standard indicators."""
+    return {
+        "peru": {
+            "PER_Amazonas": {
+                "benefit": [
+                    {"biodiversity_intactness": {"values": {"mean": 0.9077500730019198}, "total": [0.9]}},
+                    {"endangered_species": {"values": {"mean": 18.357729356162096}, "total": [18]}},
+                    {"ground_carbon": {"values": {"mean": 52.476425839602435}, "total": [52]}},
+                    {"woodfuel_harvest": {"values": {"mean": 0.05340367248356664}, "total": [0.05]}},
+                    {"forest_job": {"values": {"mean": 0.0011163512767639661}, "total": [0.001]}},
+                    {"plantation_growth_rates": {"values": {"mean": 27.651329515315897}, "total": [27]}},
+                ],
+                "constraint": [
+                    {"treecover_with_potential": {"values": {"percent": 65.35092275053587}, "total": [3925288]}},
+                ],
+                "cost": [
+                    {"opportunity_cost": {"values": {"sum": 938.1267199859027}, "total": [938]}},
+                    {"implementation_cost": {"values": {"sum": 521.7227209970567}, "total": [521]}},
+                ],
+                "suitability": {
+                    "values": [
+                        {"image": 1, "sum": 308810.2869463376},
+                        {"image": 2, "sum": 414872.70190984395},
+                        {"image": 3, "sum": 283440.90949578444},
+                        {"image": 4, "sum": 240349.0361641916},
+                        {"image": 5, "sum": 75298.45474935495},
+                        {"image": 6, "sum": 2602516.9563359786},
+                    ],
+                    "total": 3925288.3456014907,
+                },
+                "color": "#1f77b4",
+            }
+        }
+    }
+
+
+@pytest.fixture
+def multi_aoi_stats(single_aoi_stats):
+    """RecipeStatsDict with primary + 2 sub-regions, perturbed values."""
+    primary = single_aoi_stats["peru"]["PER_Amazonas"]
+
+    def perturb(area_data, factor):
+        new_data = copy.deepcopy(area_data)
+        for entry in new_data["benefit"]:
+            for content in entry.values():
+                content["values"]["mean"] *= factor
+        for entry in new_data["constraint"]:
+            for content in entry.values():
+                content["values"]["percent"] *= factor
+        for entry in new_data["cost"]:
+            for content in entry.values():
+                content["values"]["sum"] *= factor
+        for v in new_data["suitability"]["values"]:
+            v["sum"] *= factor
+        new_data["suitability"]["total"] *= factor
+        return new_data
+
+    return {
+        "peru": {
+            "PER_Amazonas": primary,
+            "site_north": perturb(primary, 0.95),
+            "site_south": perturb(primary, 0.85),
+        }
+    }
+
+
+@pytest.fixture
+def patch_result_dir(monkeypatch, tmp_path):
+    """Redirect compute output to tmp_path."""
+    from component.scripts import compute
+
+    monkeypatch.setattr(compute, "result_dir", tmp_path)
+    return tmp_path
+
+
+def read_csv_with_metadata(path: Path):
+    """Return (metadata_lines: list[str], dataframe)."""
+    text = path.read_text(encoding="utf-8")
+    metadata = [line for line in text.splitlines() if line.startswith("#")]
+    df = pd.read_csv(path, comment="#")
+    return metadata, df
+
+
+def test_round_trip_parses_with_pandas(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    assert list(df.columns) == EXPECTED_COLUMNS
+
+
+def test_metadata_header_single_aoi(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    metadata, _ = read_csv_with_metadata(Path(path))
+
+    md = "\n".join(metadata)
+    assert "# Recipe: peru" in md
+    assert re.search(r"# Generated: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", md)
+    assert "# Primary AOI: PER_Amazonas" in md
+    assert "# Scale (m): 100" in md
+    assert "# Areas: 1" in md
+    assert not any(line.startswith("# Sub-regions:") for line in metadata)
+
+
+def test_metadata_header_multi_aoi(multi_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(multi_aoi_stats)
+    metadata, _ = read_csv_with_metadata(Path(path))
+
+    md = "\n".join(metadata)
+    assert "# Primary AOI: PER_Amazonas" in md
+    assert "# Sub-regions: site_north, site_south" in md
+    assert "# Areas: 3" in md
+
+
+def test_indicator_labels_are_human_readable(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    indicators = set(df["Indicator"])
+    assert "Unrealized biomass potential" in indicators
+    assert "Biodiversity Intactness Index" in indicators
+    assert "Land opportunity cost" in indicators
+    assert "Implementation cost" in indicators
+    assert "Current tree cover less than potential" in indicators
+    assert "Very low" in indicators
+    assert "Total" in indicators
+
+
+def test_units_populated(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    non_suit = df[df["Theme"] != "Suitability"]
+    assert (non_suit["Unit"].astype(str).str.len() > 0).all(), \
+        f"Empty units in: {non_suit[non_suit['Unit'].astype(str).str.len() == 0]}"
+
+    suit = df[df["Theme"] == "Suitability"]
+    assert (suit["Unit"] == "ha").all()
+
+
+def test_constraint_unit_is_percent_of_aoi(single_aoi_stats, patch_result_dir):
+    """Constraints report % of AOI covered, regardless of the layer's native unit."""
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    constraints = df[df["Theme"] == "Constraint"]
+    assert len(constraints) > 0
+    assert (constraints["Unit"] == "% of AOI").all()
+
+
+def test_aggregation_labels(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    assert (df.loc[df["Theme"] == "Benefit", "Aggregation"] == "mean").all()
+    assert (df.loc[df["Theme"] == "Constraint", "Aggregation"] == "coverage").all()
+    assert (df.loc[df["Theme"] == "Cost", "Aggregation"] == "sum").all()
+    assert (df.loc[df["Theme"] == "Suitability", "Aggregation"] == "area").all()
+
+
+def test_numeric_precision_bounded(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    text = Path(path).read_text(encoding="utf-8")
+
+    assert "0.9077500730019198" not in text
+    assert "0.0011163512767639661" not in text
+    assert "308810.2869463376" not in text
+
+
+def test_sub_region_block_ordering(multi_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(multi_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    seen = []
+    for area in df["Area"]:
+        if area not in seen:
+            seen.append(area)
+
+    assert seen[0] == "PER — Amazonas"
+    assert seen[1] == "site_north"
+    assert seen[2] == "site_south"
+
+
+def test_aoi_type_column(multi_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(multi_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    primary = df[df["Area"] == "PER — Amazonas"]
+    assert (primary["AOI type"] == "Primary").all()
+
+    north = df[df["Area"] == "site_north"]
+    assert (north["AOI type"] == "Sub-region").all()
+
+    south = df[df["Area"] == "site_south"]
+    assert (south["AOI type"] == "Sub-region").all()
+
+
+def test_per_subregion_suitability_total(multi_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(multi_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    totals = df[(df["Theme"] == "Suitability") & (df["Indicator"] == "Total")]
+    assert len(totals) == 3
+    assert set(totals["Area"]) == {"PER — Amazonas", "site_north", "site_south"}
+    assert (totals["Aggregation"] == "area").all()
+
+
+def test_special_characters_preserved(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    units = set(df["Unit"])
+    assert "MgC/ha" in units
+    assert any("km" in u for u in units)
+
+
+def test_no_nan_strings(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    text = Path(path).read_text(encoding="utf-8")
+
+    assert ",nan," not in text.lower()
+    assert ",null," not in text.lower()
+    assert ",none," not in text.lower()
+    assert ",nan\n" not in text.lower()
+    assert ",null\n" not in text.lower()
+    assert ",none\n" not in text.lower()
+
+
+def test_custom_polygon_area_name_unchanged(multi_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(multi_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    assert "site_north" in df["Area"].values
+    assert "site_south" in df["Area"].values
+
+
+def test_within_aoi_indicator_ordering(single_aoi_stats, patch_result_dir):
+    """Within an AOI block: Benefit -> Constraint -> Cost -> Suitability classes -> Total."""
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    _, df = read_csv_with_metadata(Path(path))
+
+    themes_in_order = list(df["Theme"])
+    benefit_end = max(i for i, t in enumerate(themes_in_order) if t == "Benefit")
+    constraint_start = min(i for i, t in enumerate(themes_in_order) if t == "Constraint")
+    constraint_end = max(i for i, t in enumerate(themes_in_order) if t == "Constraint")
+    cost_start = min(i for i, t in enumerate(themes_in_order) if t == "Cost")
+    cost_end = max(i for i, t in enumerate(themes_in_order) if t == "Cost")
+    suit_start = min(i for i, t in enumerate(themes_in_order) if t == "Suitability")
+    last_idx = len(themes_in_order) - 1
+
+    assert benefit_end < constraint_start
+    assert constraint_end < cost_start
+    assert cost_end < suit_start
+    assert df.iloc[last_idx]["Indicator"] == "Total"
+
+
+def test_returned_path_has_csv_extension(single_aoi_stats, patch_result_dir):
+    from component.scripts.compute import export_as_csv
+
+    path = export_as_csv(single_aoi_stats)
+    assert Path(path).suffix == ".csv"
+    assert Path(path).exists()


### PR DESCRIPTION
## Summary

Bundles five Solara-branch improvements:

- **`fix(dashboard)` — real CSV export.** The "Download as CSV" button was JSON-encoding rows and saving them with a `.csv` extension. Replaced with a real CSV writer that includes a metadata header (`# Recipe`, `# Generated`, `# Primary AOI`, `# Sub-regions`, `# Scale (m)`, `# Areas`), human-readable indicator labels from `cm.layers`, units from `utils/layer_list.csv`, an explicit `Aggregation` column, an `AOI type` column distinguishing primary from sub-regions, bounded numeric precision, and per-sub-region Suitability totals. Side change: hardcoded `scale=100` calls in `statistics.py` replaced with a `STATS_SCALE_M` constant the exporter can read so the metadata always reflects the actual computation scale.
- **`feat(map)` — Geoman draw + custom geometries modal + legend overlay.** Consolidates custom-geometry drawing into a single modal and adds a legend overlay on the map.
- **`feat(aoi)` — LMIC gating + async DRAW auto-submit.** Limits AOI selection to LMIC countries and auto-submits drawn AOIs asynchronously.
- **`feat(recipe)` — right-panel recipe header with auto-naming.** Adds a recipe header in the right side panel with auto-naming.
- **`fix(plots)` — unclip echarts tooltips.** Adds `appendToBody=True, confine=True` to echarts tooltips so they aren't clipped inside small chart containers.

## Test plan

- [x] Open the dashboard with a single-AOI recipe, click Download — CSV opens cleanly in Excel and `pandas.read_csv(path, comment='#')`
- [x] Repeat with a multi-region recipe (primary + custom polygons): every AOI gets its own block, `AOI type` distinguishes Primary vs Sub-region, `# Sub-regions` lists them
- [x] Verify constraint rows show `Unit=% of AOI`, suitability rows show `Unit=ha`, benefits/costs show their layer's unit
- [x] Run `pytest tests/test_export_csv.py` — 16 tests pass
- [x] Draw a custom AOI on the map (Geoman) and confirm the legend overlay renders
- [x] Pick a non-LMIC country in the AOI selector and confirm gating message
- [x] Hover an echarts bar to confirm tooltips no longer clip