### PR TITLE
Pin docker base image SHA, ignore hygiene, collapsed right panel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -134,6 +134,11 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Git metadata
+.git/
+.gitignore
+.github/
+
 # IDE specific ignore
 .vscode/
 ui-tests/.yarn/

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ ui-tests/jlab_root
 
 .yarn/
 yarn.lock
+
+# Local-only docs and instructions
+docs/presentations/
+CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:latest
+FROM mambaorg/micromamba:latest@sha256:dc6e3fc34e7d8179ee2f1af3218b59bc17b2625d0ef5d31190de28ced840007f
 
 LABEL org.opencontainers.image.source="https://github.com/sepal-contrib/se.plan"
 

--- a/solara_app.py
+++ b/solara_app.py
@@ -165,7 +165,7 @@ def Page():
         dialog_width=860,
         right_panel_config=right_panel_config,
         right_panel_content=right_panel_content,
-        right_panel_open=True,
+        right_panel_open=False,
         repo_url="https://github.com/sepal-contrib/se.plan",
         docs_url="https://docs.sepal.io/en/latest/modules/dwn/seplan.html",
         model=app_model,


### PR DESCRIPTION
- Pin `mambaorg/micromamba` base image by sha256 digest (blocks tag-move / registry compromise from changing the base layer).
- Exclude `.git/`, `.github/`, `.gitignore` from the Docker build context.
- Gitignore local `CLAUDE.md` and `docs/presentations/`.
- Start the right-side info panel collapsed by default.