### PR TITLE
feat: embed map visualization on GEE asset exports

### DIFF
--- a/component/message/en/map.json
+++ b/component/message/en/map.json
@@ -50,7 +50,7 @@
                 },
                 "export": "Export",
                 "cancel": "Cancel",
-                "gee_task_success" : "The task <i>'{}'</i> have been tasked in your <u><a class='success--text' href='https://code.earthengine.google.com/tasks'>GEE account</a></u>. ",
+                "gee_task_success" : "The task <i>'{name}'</i> have been tasked in your <u><a class='success--text' href='https://console.cloud.google.com/earth-engine/tasks?project={project}'>GEE account</a></u>. ",
                 "error": {
                     "no_recipe" : "Before exporting the map, you need to save the recipe."
                 }

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -1,18 +1,191 @@
+import logging
 from pathlib import Path
-from typing import List, Literal, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 import ee
-
 from ipyleaflet import TileLayer
-
 from sepal_ui import mapping as sm
+from sepal_ui.mapping.visualization import set_viz_params
+from sepal_ui.scripts.gee import get_ee_project
 from sepal_ui.scripts.gee_interface import GEEInterface
 
+from component import parameter as cp
 from component.message import cm
 from component.scripts.assets import default_asset_id
-import logging
 
 logger = logging.getLogger("SEPLAN")
+
+
+def get_ee_project_id(gee_interface: GEEInterface) -> str:
+    """Return the Cloud project id backing the current Earth Engine session.
+
+    Prefers the session-backed project id (the user's project that actually
+    submits the export task), falling back to the default project reported by
+    the Earth Engine API when no session is attached (e.g. local runs).
+
+    Args:
+        gee_interface: The interface used to run Earth Engine operations.
+
+    Returns:
+        The Cloud project id (e.g. ``ee-indonesia-gwl``).
+    """
+    session = getattr(gee_interface, "session", None)
+    project_id = getattr(session, "project_id", None)
+
+    return project_id or get_ee_project()
+
+
+async def get_layer_min_max(
+    image: ee.Image, aoi: ee.FeatureCollection, gee_interface: GEEInterface
+) -> Tuple[float, float]:
+    """Compute the (min, max) of an image over the AOI.
+
+    Mirrors the reducer used by the layer preview map so the embedded
+    visualization stretch matches what users saw on screen.
+
+    Args:
+        image: The single-band image to reduce.
+        aoi: The area of interest to reduce over.
+        gee_interface: The interface used to run the (awaited) reduction.
+
+    Returns:
+        A ``(min, max)`` tuple rounded to two decimals.
+    """
+    reduced = image.clip(aoi.geometry()).reduceRegion(
+        reducer=ee.Reducer.minMax(),
+        geometry=aoi.geometry(),
+        scale=1,
+        maxPixels=int(1e5),
+        bestEffort=True,
+        tileScale=16,
+    )
+    values = await gee_interface.get_info_async(reduced)
+    values = values or {}
+
+    min_ = next((v for k, v in values.items() if k.endswith("_min")), None)
+    max_ = next((v for k, v in values.items() if k.endswith("_max")), None)
+
+    min_ = 0 if min_ is None else round(min_, 2)
+    max_ = min_ + 1 if max_ is None else round(max_, 2)
+
+    return min_, max_
+
+
+def get_export_viz_params(
+    theme: str,
+    id_: str,
+    min_max: Optional[Tuple[float, float]] = None,
+    bands: Optional[List[str]] = None,
+) -> dict:
+    """Build ``set_viz_params`` kwargs that reproduce a layer's on-map styling.
+
+    The returned SEPAL-convention parameters mirror the palettes the app uses
+    on the map (``layer_vis`` for the suitability indices, ``map_vis`` for the
+    individual themes) so an exported asset styles itself when reloaded.
+
+    Args:
+        theme: The export theme — ``index``, ``benefit``, ``constraint`` or
+            ``cost``.
+        id_: The layer id within the theme. Unused today; kept so per-layer
+            palettes can be added without changing callers.
+        min_max: Pre-computed ``(min, max)`` for the continuous themes
+            (``benefit`` / ``cost``). Falls back to the palette defaults.
+        bands: The band name(s) the visualization targets. Added as
+            ``visualization_*_bands`` when provided so SEPAL readers know
+            which band to render.
+
+    Returns:
+        A kwargs dict for :func:`set_viz_params`, or ``{}`` when the theme has
+        no defined palette.
+    """
+    if theme == "index":
+        params = {
+            "name": "default",
+            "type": "continuous",
+            "min": cp.layer_vis["min"],
+            "max": cp.layer_vis["max"],
+            "palette": cp.layer_vis["palette"],
+        }
+    elif theme == "constraint":
+        binary = cp.map_vis["binary"]
+        params = {
+            "name": "default",
+            "type": "categorical",
+            "values": [0, 1],
+            "labels": binary["names"],
+            "min": binary["min"],
+            "max": binary["max"],
+            "palette": binary["palette"],
+        }
+    elif theme in ("benefit", "cost"):
+        gradient = cp.map_vis["gradient"]
+        min_, max_ = min_max or (gradient["min"], gradient["max"])
+        params = {
+            "name": "default",
+            "type": "continuous",
+            "min": min_,
+            "max": max_,
+            "palette": gradient["palette"],
+        }
+    else:
+        return {}
+
+    if bands:
+        params["bands"] = bands
+
+    return params
+
+
+async def apply_export_viz(
+    image: ee.Image,
+    theme: str,
+    id_: str,
+    aoi: ee.FeatureCollection,
+    gee_interface: GEEInterface,
+) -> ee.Image:
+    """Annotate ``image`` with the map's visualization as SEPAL properties.
+
+    Continuous themes (``benefit`` / ``cost``) get a data-driven stretch; the
+    suitability ``index`` and ``constraint`` themes use their fixed palettes.
+    Returns the image unchanged for themes without a defined palette, and never
+    raises — a failed stretch falls back to the palette defaults.
+
+    All Earth Engine reads use the awaited async interface, so this must be
+    called from an async context (e.g. a ``gee_interface.create_task`` body).
+
+    Args:
+        image: The image about to be exported to an Earth Engine asset.
+        theme: The export theme.
+        id_: The layer id within the theme.
+        aoi: The area of interest, used to compute the stretch.
+        gee_interface: The interface used to run the awaited Earth Engine reads.
+
+    Returns:
+        The image carrying ``visualization_*`` properties, or the original
+        image when the theme has no palette.
+    """
+    # cheap purity check first so an unknown theme makes no Earth Engine calls
+    if not get_export_viz_params(theme, id_):
+        return image
+
+    min_max = None
+    if theme in ("benefit", "cost"):
+        try:
+            min_max = await get_layer_min_max(image, aoi, gee_interface)
+        except Exception:
+            logger.debug("min/max computation failed; using palette defaults")
+
+    # resolve the real band name so the asset carries visualization_*_bands
+    bands = None
+    try:
+        band_names = await gee_interface.get_info_async(image.bandNames())
+        bands = band_names[:1] if band_names else None
+    except Exception:
+        logger.debug("band name resolution failed; exporting without bands")
+
+    viz_params = get_export_viz_params(theme, id_, min_max, bands)
+
+    return set_viz_params(image, **viz_params)
 
 
 def create_layer(map_id_dict: dict, name: str = "", visible: bool = True) -> TileLayer:
@@ -55,16 +228,15 @@ def get_limits(
     """Computes limits or histogram keys for the given Earth Engine image based on the specified data type.
 
     Args:
+        gee_interface (GEEInterface): The interface used to run Earth Engine operations.
         asset (str): Google Earth Engine asset ID.
         data_type (str): Either 'binary', 'continuous', or any other type indicating the type of data processing.
         aoi (ee.Geometry): Area of interest.
-        band_index (int, optional): Band index to select from the image. Defaults to 0.
         factor (int, optional): Factor to multiply the nominal scale of the image. Defaults to 2 (i.e. 2x the nominal scale
 
     Returns:
         list: A list containing either min-max values or histogram keys depending on the data_type.
     """
-
     # We know that the treecover_with_potential asset is binary
     if asset == default_asset_id:
         return [0, 1]
@@ -138,7 +310,6 @@ async def get_limits_async(
     Returns:
         list: A list containing either min-max values or histogram keys depending on the data_type.
     """
-
     # We know that the treecover_with_potential asset is binary
     if asset == default_asset_id:
         return [0, 1]
@@ -197,3 +368,28 @@ def get_gee_recipe_folder(recipe_name: str, gee_interface: GEEInterface) -> Path
     """Create a folder for the recipe in GEE."""
     recipe_folder = Path("seplan") / recipe_name
     return Path(gee_interface.create_folder(recipe_folder.as_posix()))
+
+
+async def get_gee_recipe_folder_async(
+    recipe_name: str, gee_interface: GEEInterface
+) -> Path:
+    """Create (awaited) the recipe's GEE folder and return its path.
+
+    Async mirror of :func:`get_gee_recipe_folder` for use inside
+    ``gee_interface.create_task`` bodies, where blocking calls would deadlock.
+
+    Args:
+        recipe_name: The recipe stem used as the folder name.
+        gee_interface: The interface used to create the folder.
+
+    Returns:
+        The created folder as a :class:`~pathlib.Path`.
+    """
+    recipe_folder = Path("seplan") / recipe_name
+    created = await gee_interface.create_folder_async(recipe_folder.as_posix())
+
+    # create_folder_async may return the asset path (str) or an asset dict
+    if isinstance(created, dict):
+        created = created.get("name") or created.get("id") or created.get("path")
+
+    return Path(created)

--- a/component/widget/export_dialog.py
+++ b/component/widget/export_dialog.py
@@ -1,12 +1,10 @@
+import logging
 from pathlib import Path
 from typing import Literal
 
 import ee
 import rasterio as rio
 from matplotlib.colors import to_rgba
-from component.scripts.gee import get_gee_recipe_folder
-from component.scripts.ui_helpers import parse_export_name
-from component.widget.buttons import TextBtn
 from sepal_ui import sepalwidgets as sw
 from sepal_ui.scripts import gee
 from sepal_ui.scripts import utils as su
@@ -15,10 +13,16 @@ from component import parameter as cp
 from component import scripts as cs
 from component.message import cm
 from component.model.recipe import Recipe
+from component.scripts.gee import (
+    apply_export_viz,
+    get_ee_project_id,
+    get_gee_recipe_folder_async,
+)
 from component.scripts.seplan import asset_to_image, mask_image, quintiles
-from component.widget.base_dialog import BaseDialog
+from component.scripts.ui_helpers import parse_export_name
 from component.widget.alert_state import Alert
-import logging
+from component.widget.base_dialog import BaseDialog
+from component.widget.buttons import TextBtn
 
 logger = logging.getLogger("SEPLAN")
 
@@ -52,9 +56,9 @@ class ExportMapDialog(BaseDialog):
         )
         self.w_asset = sw.Select(items=[], v_model=[])
 
-        # add alert and btn component for the loading_button
+        # alert + action buttons (the export button runs an async task)
         self.alert = alert or sw.Alert()
-        self.btn = TextBtn(cm.map.dialog.export.export)
+        self.btn = sw.TaskButton(cm.map.dialog.export.export, small=True, class_="mr-2")
         self.btn_cancel = TextBtn(cm.map.dialog.export.cancel, outlined=True)
 
         title = sw.CardTitle(children=[cm.map.dialog.export.title])
@@ -80,8 +84,8 @@ class ExportMapDialog(BaseDialog):
 
         super().__init__()
 
-        # add js behaviour
-        self.btn.on_event("click", self.on_download)
+        # the export button runs the (async) export task on the GEE loop
+        self.btn.configure(task_factory=self._create_export_task)
         self.btn_cancel.on_event("click", self.close_dialog)
 
         # Let's observe "updated" trait, this one changes only when there's change
@@ -196,29 +200,16 @@ class ExportMapDialog(BaseDialog):
                 # TODO: check if we have to normalize or not
                 return ee_asset
 
-    def set_data(self, dataset, geometry, name, aoi_name):
-        """set the dataset and the geometry to allow the download."""
-        # add vizualization properties to the image
-        # cast to image as set is a ee.Element method
-        palette = ",".join(cp.no_data_color + cp.gradient(5))
-        self.dataset = ee.Image(
-            dataset.set(
-                {
-                    "visualization_0_bands": "constant",
-                    "visualization_0_max": 5,
-                    "visualization_0_min": 0,
-                    "visualization_0_name": "restauration index",
-                    "visualization_0_palette": palette,
-                    "visualization_0_type": "continuous",
-                }
-            )
+    def _create_export_task(self):
+        """Build the GEE task that runs the export (wired to the TaskButton)."""
+        return self.recipe.gee_interface.create_task(
+            func=self._export,
+            key="export_map",
+            on_error=lambda e: self.alert.add_msg(str(e), type_="error"),
         )
 
-        return self
-
-    @su.loading_button()
-    def on_download(self, *_):
-        """download the dataset using the given parameters."""
+    async def _export(self):
+        """Export the selected layer using awaited Earth Engine calls only."""
         aoi = self.recipe.seplan.aoi_model.feature_collection
 
         if not aoi:
@@ -227,44 +218,60 @@ class ExportMapDialog(BaseDialog):
         if not self.recipe.recipe_session_path:
             raise Exception(cm.map.dialog.export.error.no_recipe)
 
+        gee_interface = self.recipe.gee_interface
+
         # The value from the w_asset is a tuple with (theme, id_)
-        ee_image = self.get_ee_image(*self.w_asset.v_model)
+        theme, id_ = self.w_asset.v_model
+        ee_image = self.get_ee_image(theme, id_)
 
         recipe_name = str(Path(self.recipe.recipe_session_path).stem)
 
-        # set the parameters
-        name = "_".join(self.w_asset.v_model) + "_" + recipe_name
-
-        # Parse the name to provide a better description
-        name = parse_export_name(name)
+        # set the parameters and parse the name for a better description
+        name = parse_export_name("_".join(self.w_asset.v_model) + "_" + recipe_name)
 
         export_params = {
-            # "image": ee_image,
             "description": name,
             "scale": self.w_scale.v_model,
             "region": aoi.geometry(),
             "max_pixels": 1e13,
         }
 
+        # resolve the user's Cloud project so the success message can deep-link
+        # to the Earth Engine tasks page scoped to that project
+        project_id = get_ee_project_id(gee_interface)
+
         # launch the task
         if self.w_method.v_model == "gee":
 
-            recipe_gee_folder = get_gee_recipe_folder(
-                recipe_name, self.recipe.gee_interface
+            recipe_gee_folder = await get_gee_recipe_folder_async(
+                recipe_name, gee_interface
             )
             logger.debug(f"recipe_gee_folder>>>>>>>>>>>> {recipe_gee_folder}")
             export_params.update(
                 asset_id=str(recipe_gee_folder / name), description=f"{name}"
             )
-            self.recipe.gee_interface.export_image_to_asset(ee_image, **export_params)
 
-            msg = sw.Markdown(cm.map.dialog.export.gee_task_success.format(name))
+            # embed the map's visualization so the asset styles itself when
+            # reloaded in se.plan / other SEPAL recipes / the Code Editor
+            ee_image = await apply_export_viz(ee_image, theme, id_, aoi, gee_interface)
+
+            await gee_interface.export_image_to_asset_async(ee_image, **export_params)
+
+            msg = sw.Markdown(
+                cm.map.dialog.export.gee_task_success.format(
+                    name=name, project=project_id
+                )
+            )
             self.alert.add_msg(msg, "success")
 
         elif self.w_method.v_model == "gdrive":
 
-            self.recipe.gee_interface.export_image_to_drive(ee_image, **export_params)
-            msg = sw.Markdown(cm.map.dialog.export.gee_task_success.format(name))
+            await gee_interface.export_image_to_drive_async(ee_image, **export_params)
+            msg = sw.Markdown(
+                cm.map.dialog.export.gee_task_success.format(
+                    name=name, project=project_id
+                )
+            )
             self.alert.add_msg(msg, "success")
 
         elif self.w_method.v_model == "sepal":

--- a/tests/test_export_viz.py
+++ b/tests/test_export_viz.py
@@ -1,0 +1,105 @@
+"""Tests for the export visualization parameters (matching the on-map styling)."""
+
+import asyncio
+
+import ee
+
+from component import parameter as cp
+from component.scripts.gee import apply_export_viz, get_export_viz_params
+
+
+class _StubGee:
+    """Minimal gee_interface stand-in: resolves ee objects via ``get_info_async``."""
+
+    async def get_info_async(self, ee_object):
+        return ee_object.getInfo()
+
+
+def test_index_uses_layer_vis():
+    params = get_export_viz_params("index", "constraint_index")
+
+    assert params["name"] == "default"
+    assert params["type"] == "continuous"
+    assert params["min"] == cp.layer_vis["min"]
+    assert params["max"] == cp.layer_vis["max"]
+    assert params["palette"] == cp.layer_vis["palette"]
+
+
+def test_constraint_is_binary_categorical():
+    binary = cp.map_vis["binary"]
+    params = get_export_viz_params("constraint", "any")
+
+    assert params["type"] == "categorical"
+    assert params["values"] == [0, 1]
+    assert params["labels"] == binary["names"]
+    assert params["min"] == binary["min"]
+    assert params["max"] == binary["max"]
+    assert params["palette"] == binary["palette"]
+
+
+def test_benefit_uses_provided_min_max_with_gradient_palette():
+    params = get_export_viz_params("benefit", "any", min_max=(1.0, 4.5))
+
+    assert params["palette"] == cp.map_vis["gradient"]["palette"]
+    assert params["min"] == 1.0
+    assert params["max"] == 4.5
+
+
+def test_cost_falls_back_to_gradient_defaults_without_min_max():
+    gradient = cp.map_vis["gradient"]
+    params = get_export_viz_params("cost", "any")
+
+    assert params["min"] == gradient["min"]
+    assert params["max"] == gradient["max"]
+    assert params["palette"] == gradient["palette"]
+
+
+def test_unknown_theme_returns_empty():
+    assert get_export_viz_params("mystery", "any") == {}
+
+
+def test_bands_included_when_provided():
+    params = get_export_viz_params("index", "any", bands=["constant"])
+    assert params["bands"] == ["constant"]
+
+
+def test_bands_absent_when_not_provided():
+    assert "bands" not in get_export_viz_params("index", "any")
+
+
+def test_apply_export_viz_is_noop_for_unknown_theme():
+    sentinel = object()
+    # unknown theme -> image returned unchanged, no GEE calls made
+    result = asyncio.run(apply_export_viz(sentinel, "mystery", "any", None, None))
+    assert result is sentinel
+
+
+def test_apply_export_viz_embeds_full_index_properties():
+    # ee.Image.constant(3) has a single band named "constant"
+    styled = asyncio.run(
+        apply_export_viz(
+            ee.Image.constant(3), "index", "constraint_index", None, _StubGee()
+        )
+    )
+    props = styled.toDictionary().getInfo()
+
+    assert props["visualization_0_name"] == "default"
+    assert props["visualization_0_type"] == "continuous"
+    assert props["visualization_0_bands"] == "constant"
+    assert props["visualization_0_min"] == "0"
+    assert props["visualization_0_max"] == "5"
+    assert props["visualization_0_palette"] == ",".join(cp.layer_vis["palette"])
+
+
+def test_apply_export_viz_benefit_embeds_gradient_and_bands():
+    aoi = ee.FeatureCollection(ee.Geometry.Rectangle([0, 0, 1, 1]))
+    styled = asyncio.run(
+        apply_export_viz(ee.Image.constant(3), "benefit", "any", aoi, _StubGee())
+    )
+    props = styled.toDictionary().getInfo()
+
+    gradient_palette = ",".join(cp.map_vis["gradient"]["palette"])
+    assert props["visualization_0_palette"] == gradient_palette
+    assert props["visualization_0_bands"] == "constant"
+    # data-driven stretch: a constant image has min == max
+    assert props["visualization_0_min"] == props["visualization_0_max"]


### PR DESCRIPTION
Asset exports now carry SEPAL `visualization_*` properties matching the on-map styling, so reloaded assets self-style (in se.plan, other recipes, the Code Editor).

- Per-theme palettes: `index` → `layer_vis`; `benefit`/`cost` → gradient with a data-driven stretch; `constraint` → binary. Band name resolved from the image so `visualization_0_bands` is included.
- `gee_task_success` links to the Cloud Console tasks page, scoped to the user's project.
- Export flow is now async (`create_task` + `*_async` + `TaskButton`); removed the dead `set_data`.

Asset-only (EE properties don't survive a Drive GeoTIFF). Tests in `tests/test_export_viz.py`; export tests pass; pre-commit clean.
