### PR TITLE
build: require pysepal>=3.6.1 for set_viz_params

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ toml
 ipecharts>=1.2.0
 rasterio<1.3.11 # Leave it here even if it's already in the sepal_ui requirements. Check https://github.com/openforis/sepal/issues/328
 
-pysepal>=3.5.0
+pysepal>=3.6.1
 
 https://github.com/dfguerrerom/ipyleaflet/raw/634bcf22c09034a917819437358d5840fa72ac41/wheels/jupyter_leaflet-0.20.0-py3-none-any.whl
 https://github.com/dfguerrerom/ipyleaflet/raw/634bcf22c09034a917819437358d5840fa72ac41/wheels/ipyleaflet-0.20.0-py3-none-any.whl


### PR DESCRIPTION
The merged #264 export-visualization imports `set_viz_params`, added in pysepal 3.6.1, but `requirements.txt` was left at `>=3.5.0`. Bump it.