### PR TITLE
fix: scenario-compare deadlock and recipe path drift

### DIFF
--- a/component/model/recipe.py
+++ b/component/model/recipe.py
@@ -216,6 +216,10 @@ class Recipe(HasTraits):
 
         save_file(full_recipe_path, data, self.sepal_session)
 
+        # The path we just wrote is now the canonical session path. Keep the
+        # model in sync so the header, exports and asset naming all agree
+        # (str() because traitlets compares/stores the Unicode value).
+        self.recipe_session_path = str(full_recipe_path)
         self.new_changes = 0
 
         return full_recipe_path

--- a/component/tile/recipe_tile.py
+++ b/component/tile/recipe_tile.py
@@ -226,7 +226,6 @@ class RecipeView(sw.Layout):
     @observe("recipe_session_path")
     def test_recipe_path(self, change):
         """Test if the recipe path is valid."""
-        print("testoutput")
         logger.debug(f"Testing recipe path: {self.recipe_session_path}")
 
     def session_path_handler(self, change):
@@ -252,8 +251,9 @@ class RecipeView(sw.Layout):
         self.recipe.reset()
         self.alert.set_state("reset", "all", "done")
 
-        # update current session path
-        self.recipe_session_path = self.recipe.get_recipe_path(
+        # update current session path on the model (source of truth); the
+        # one-way link mirrors it into this view's recipe_session_path.
+        self.recipe.recipe_session_path = self.recipe.get_recipe_path(
             self.card_new.recipe_name
         )
 
@@ -308,8 +308,8 @@ class RecipeView(sw.Layout):
         # Success - recipe loaded normally
         self._pending_validation = None
 
-        # Assign the recipe path to the current session path
-        self.recipe_session_path = self.load_dialog.load_recipe_path
+        # Assign the recipe path to the model (source of truth)
+        self.recipe.recipe_session_path = self.load_dialog.load_recipe_path
 
         self.alert.set_state("load", "all", "done")
 
@@ -340,8 +340,9 @@ class RecipeView(sw.Layout):
 
         self.recipe.save(recipe_path)
 
-        # Assign the recipe path to the current session path
-        self.recipe_session_path = str(recipe_path)
+        # Assign the recipe path to the model (source of truth); save() already
+        # sets it, this keeps the intent explicit and is idempotent.
+        self.recipe.recipe_session_path = str(recipe_path)
 
         self.alert.add_msg(cm.recipe.states.save.format(recipe_path), type_="success")
 
@@ -369,8 +370,8 @@ class RecipeView(sw.Layout):
                 sanitized_data, self._pending_validation.recipe_path
             )
 
-            # Assign the recipe path to the current session path
-            self.recipe_session_path = self._pending_validation.recipe_path
+            # Assign the recipe path to the model (source of truth)
+            self.recipe.recipe_session_path = self._pending_validation.recipe_path
 
             # Show success message with error count
             error_count = self._pending_validation.total_errors
@@ -407,8 +408,8 @@ class RecipeView(sw.Layout):
             # Reset all models to default state
             self.recipe.reset()
 
-            # Clear recipe path
-            self.recipe_session_path = ""
+            # Clear recipe path on the model (source of truth)
+            self.recipe.recipe_session_path = ""
 
             # Update the alert
             self.alert.add_msg(

--- a/component/widget/scenarios_dialog.py
+++ b/component/widget/scenarios_dialog.py
@@ -208,6 +208,14 @@ class CompareScenariosDialog(BaseDialog):
         recipes = []
         self.validate_scenarios()
 
+        # Resolve the GEE assets folder up-front on the loop. Without it, the
+        # Recipe() constructor below reaches pysepal's AoiModel.__init__, which
+        # falls back to the *blocking* gee_interface.get_folder(). Since this
+        # coroutine runs on the GEE event-loop thread, that blocking call trips
+        # pysepal's deadlock guard. Passing a resolved folder skips that branch.
+        if folder is None and self.gee_interface is not None:
+            folder = await self.gee_interface.get_folder_async()
+
         for _, recipe_data in self.scenario_inputs.recipe_paths.items():
             recipe_path = recipe_data["path"]
             recipe = Recipe(

--- a/tests/test_recipe_header_sync.py
+++ b/tests/test_recipe_header_sync.py
@@ -1,0 +1,67 @@
+"""Regression tests for recipe session-path source-of-truth.
+
+The right-panel header (RecipeHeader) reads ``recipe.recipe_session_path``
+directly, while RecipeView keeps a one-way mirror copy. These tests guard
+against the drift where the tile's new/save flows updated only the mirror,
+leaving the model (and therefore the header, exports and asset naming) stale.
+"""
+
+from component.model.recipe import Recipe
+from component.tile.recipe_tile import RecipeView
+
+
+def test_save_updates_model_session_path(tmp_path):
+    """Recipe.save makes the saved path the canonical session path."""
+    recipe = Recipe()
+    target = tmp_path / "saved_recipe.json"
+
+    recipe.save(str(target))
+
+    assert recipe.recipe_session_path == str(target)
+
+
+def test_new_event_writes_model_not_just_view():
+    """Creating a new recipe via the tile must update the model trait.
+
+    Previously ``new_event`` set only ``RecipeView.recipe_session_path`` (the
+    mirror), so the header kept showing the old name.
+    """
+    recipe = Recipe()
+    view = RecipeView(recipe=recipe)
+
+    view.card_new.recipe_name = "my_new_recipe"
+    # new_event is a loading_button-wrapped handler, invoked like an ipyvuetify
+    # event callback: (widget, event, data).
+    view.new_event(None, None, None)
+
+    expected = recipe.get_recipe_path("my_new_recipe")
+    # the model (source of truth) is updated, not just the view's copy
+    assert recipe.recipe_session_path == expected
+    # and the view's mirror reflects it via the one-way link
+    assert view.recipe_session_path == expected
+
+
+def test_save_event_writes_model(tmp_path):
+    """Saving via the tile keeps the model path in sync with the written file."""
+    recipe = Recipe()
+    view = RecipeView(recipe=recipe)
+
+    # seed a session path so save_event renames within its folder
+    recipe.recipe_session_path = str(tmp_path / "old_name.json")
+    view.card_save.recipe_name = "new_name"
+
+    view.save_event(None, None, None)
+
+    expected = str(tmp_path / "new_name.json")
+    assert recipe.recipe_session_path == expected
+    assert view.recipe_session_path == expected
+
+
+def test_view_trait_mirrors_model():
+    """The view's recipe_session_path is a pure mirror of the model trait."""
+    recipe = Recipe()
+    view = RecipeView(recipe=recipe)
+
+    recipe.recipe_session_path = "/tmp/some/path.json"
+
+    assert view.recipe_session_path == "/tmp/some/path.json"


### PR DESCRIPTION
Three changes.

### GEE deadlock when comparing scenarios
`read_recipes_async` built `Recipe`s without a `folder` inside a `create_task`, so pysepal's `AoiModel.__init__` called the blocking `get_folder()` on the GEE event-loop thread → deadlock guard fired ("Failed to add layer" / "Failed to compute statistics"). Now resolves the folder via `get_folder_async()` before building recipes.

### recipe_session_path drift (header vs tile)
The recipe tile kept a one-way mirror of `recipe_session_path` and its new/save flows wrote only the mirror, leaving the model — and thus the header, CSV/stats exports and asset naming — stale. Handlers now write the model trait (the view stays a pure mirror); `Recipe.save()` records the saved path.

### dedupe recipe-dict building
`Recipe.save()` and the header inspector built the same in-memory dict, differing only by a `signature` string (`"live-session"` vs the real hash). Extracted `Recipe.to_dict()` + a named `RECIPE_SIGNATURE` constant used by both; dropped the duplicate builder and the sentinel.

Adds `tests/test_recipe_header_sync.py` (6 tests).
