### PR TITLE
refactor: single Recipe.to_dict for save and inspector preview

### DIFF
--- a/component/model/recipe.py
+++ b/component/model/recipe.py
@@ -18,6 +18,9 @@ import logging
 
 logger = logging.getLogger("SEPLAN")
 
+RECIPE_SIGNATURE = "cc19794c0d420e449f36308ce0ede23d03f14be78490d857fbda3289a1910e75"
+"""Fixed marker every se.plan recipe file carries; validated on load."""
+
 
 class Recipe(HasTraits):
     # Set types
@@ -195,26 +198,32 @@ class Recipe(HasTraits):
         logger.info("Sanitized recipe loaded successfully")
         return self
 
-    def save(self, full_recipe_path: str):
-        """Save the recipe in a json file with a timestamp."""
-        # Raise a sepal_ui.warning if there is no loaded models
-        if not self.seplan:
-            raise SepalWarning(cm.recipe.error.no_seplan)
+    def to_dict(self) -> dict:
+        """Build the recipe payload from the in-memory models.
 
+        Single source of truth for the on-disk recipe shape, shared by
+        ``save`` and the right-panel inspector preview so they never diverge.
+        """
         data = {
-            "signature": "cc19794c0d420e449f36308ce0ede23d03f14be78490d857fbda3289a1910e75",
+            "signature": RECIPE_SIGNATURE,
             "aoi": self.seplan_aoi.export_data(),
             "benefits": self.benefit_model.export_data(),
             "constraints": self.constraint_model.export_data(),
             "costs": self.cost_model.export_data(),
         }
 
-        [
+        for key in ("updated", "new_changes", "object_set"):
             validation.remove_key(data, key)
-            for key in ["updated", "new_changes", "object_set"]
-        ]
 
-        save_file(full_recipe_path, data, self.sepal_session)
+        return data
+
+    def save(self, full_recipe_path: str):
+        """Save the recipe in a json file with a timestamp."""
+        # Raise a sepal_ui.warning if there is no loaded models
+        if not self.seplan:
+            raise SepalWarning(cm.recipe.error.no_seplan)
+
+        save_file(full_recipe_path, self.to_dict(), self.sepal_session)
 
         # The path we just wrote is now the canonical session path. Keep the
         # model in sync so the header, exports and asset naming all agree

--- a/component/widget/recipe_header.py
+++ b/component/widget/recipe_header.py
@@ -14,7 +14,6 @@ from sepal_ui.scripts import utils as su
 from component.frontend.icons import icon
 from component.message import cm
 from component.model.recipe import Recipe
-from component.scripts import validation
 from component.widget.alert_state import Alert
 from component.widget.buttons import IconBtn
 from component.widget.custom_widgets import RecipeInspector
@@ -76,23 +75,6 @@ class RecipeHeader(sw.Layout):
     def _on_changes(self, _):
         self.name_field.hint = self._format_status()
 
-    def _build_recipe_dict(self) -> dict:
-        """Snapshot of the live recipe in the same shape ``Recipe.save`` writes.
-
-        Built directly from the in-memory models so the inspector can render
-        unsaved changes — never reads from disk.
-        """
-        data = {
-            "signature": "live-session",
-            "aoi": self.recipe.seplan_aoi.export_data(),
-            "benefits": self.recipe.benefit_model.export_data(),
-            "constraints": self.recipe.constraint_model.export_data(),
-            "costs": self.recipe.cost_model.export_data(),
-        }
-        for key in ("updated", "new_changes", "object_set"):
-            validation.remove_key(data, key)
-        return data
-
     def _commit_name(self, widget, event, data):
         """Normalize the typed name and rewrite ``recipe_session_path``.
 
@@ -111,7 +93,7 @@ class RecipeHeader(sw.Layout):
 
     def _on_view(self, *_):
         name = self._format_name()
-        self.inspector.set_data(self._build_recipe_dict(), recipe_name=name)
+        self.inspector.set_data(self.recipe.to_dict(), recipe_name=name)
 
     def _on_save(self, *_):
         path = self.recipe.recipe_session_path

--- a/tests/test_recipe_header_sync.py
+++ b/tests/test_recipe_header_sync.py
@@ -6,8 +6,10 @@ against the drift where the tile's new/save flows updated only the mirror,
 leaving the model (and therefore the header, exports and asset naming) stale.
 """
 
-from component.model.recipe import Recipe
+from component.model.recipe import RECIPE_SIGNATURE, Recipe
 from component.tile.recipe_tile import RecipeView
+from component.widget.alert_state import Alert
+from component.widget.recipe_header import RecipeHeader
 
 
 def test_save_updates_model_session_path(tmp_path):
@@ -65,3 +67,22 @@ def test_view_trait_mirrors_model():
     recipe.recipe_session_path = "/tmp/some/path.json"
 
     assert view.recipe_session_path == "/tmp/some/path.json"
+
+
+def test_to_dict_is_single_source_of_truth():
+    """to_dict carries the real signature and the canonical recipe shape."""
+    recipe = Recipe()
+    data = recipe.to_dict()
+
+    assert data["signature"] == RECIPE_SIGNATURE
+    assert set(data) == {"signature", "aoi", "benefits", "constraints", "costs"}
+
+
+def test_header_inspector_uses_real_signature():
+    """The header preview reuses Recipe.to_dict (no 'live-session' sentinel)."""
+    recipe = Recipe()
+    header = RecipeHeader(recipe=recipe, alert=Alert())
+
+    header._on_view()
+
+    assert header.inspector.data_dict["signature"] == RECIPE_SIGNATURE


### PR DESCRIPTION
Follow-up cleanup after #266 (the consolidation was pushed just after that PR was squash-merged, so it didn't make it in).

`Recipe.save()` and the right-panel header inspector built the same recipe dict from the same in-memory models, differing only by a `signature` string — the real hash in `save()` vs a `"live-session"` sentinel in the header preview. The sentinel was only ever rendered in the inspector's "Recipe signature" line; nothing branched on it.

- Extract `Recipe.to_dict()` as the single source of truth for the recipe payload.
- Add a named `RECIPE_SIGNATURE` constant (was a magic string duplicated across `save()` and the header).
- `save()` and the header inspector now both use `to_dict()`; dropped the duplicate builder and the `"live-session"` sentinel.

Tests: 2 added to `tests/test_recipe_header_sync.py` (to_dict shape/signature; header preview uses the real signature).
