### PR TITLE
test: green the test suite — fix stale tests and enable pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
 ]
 
@@ -68,3 +69,4 @@ version_files = [
 addopts = [
     "--import-mode=importlib",
 ]
+asyncio_mode = "auto"

--- a/tests/test_batched_fallback.py
+++ b/tests/test_batched_fallback.py
@@ -3,7 +3,23 @@
 import asyncio
 from unittest.mock import Mock, AsyncMock, patch
 
+import ee
 import pytest
+
+
+def _img():
+    """A real, constructable ee.Image standing in for a layer.
+
+    The statistics code builds lazy ee graphs from these inputs; only
+    ``get_info_async`` (mocked in these tests) actually reaches GEE, so the
+    inputs just need to be valid ee objects, not Mocks.
+    """
+    return ee.Image(1)
+
+
+def _fc():
+    """A real, constructable ee.FeatureCollection standing in for an AOI."""
+    return ee.FeatureCollection([ee.Feature(ee.Geometry.Point([0, 0]))])
 
 
 def create_mock_recipe():
@@ -18,27 +34,27 @@ def create_mock_recipe():
     mock_aoi_model = Mock()
     mock_seplan.aoi_model = mock_aoi_model
 
-    main_features = {"Main AOI": {"ee_feature": Mock(), "color": "#FF0000"}}
+    main_features = {"Main AOI": {"ee_feature": _fc(), "color": "#FF0000"}}
     secondary_features = {
-        "Sub AOI 1": {"ee_feature": Mock(), "color": "#00FF00"},
-        "Sub AOI 2": {"ee_feature": Mock(), "color": "#0000FF"},
+        "Sub AOI 1": {"ee_feature": _fc(), "color": "#00FF00"},
+        "Sub AOI 2": {"ee_feature": _fc(), "color": "#0000FF"},
     }
     mock_aoi_model.get_ee_features.return_value = (main_features, secondary_features)
 
     mock_seplan.get_benefits_list.return_value = [
-        (Mock(), "Benefit 1"),
-        (Mock(), "Benefit 2"),
-        (Mock(), "Benefit 3"),
+        (_img(), "Benefit 1"),
+        (_img(), "Benefit 2"),
+        (_img(), "Benefit 3"),
     ]
     mock_seplan.get_costs_list.return_value = [
-        (Mock(), "Cost 1"),
-        (Mock(), "Cost 2"),
+        (_img(), "Cost 1"),
+        (_img(), "Cost 2"),
     ]
     mock_seplan.get_masked_constraints_list.return_value = [
-        (Mock(), "Constraint 1"),
-        (Mock(), "Constraint 2"),
+        (_img(), "Constraint 1"),
+        (_img(), "Constraint 2"),
     ]
-    mock_seplan.get_constraint_index.return_value = Mock()
+    mock_seplan.get_constraint_index.return_value = _img()
 
     return mock_recipe
 
@@ -91,12 +107,12 @@ async def test_fallback_on_429_error():
 
     mock_recipe = create_mock_recipe()
     # Simplify to single AOI for fallback test
-    main_features = {"Main AOI": {"ee_feature": Mock(), "color": "#FF0000"}}
+    main_features = {"Main AOI": {"ee_feature": _fc(), "color": "#FF0000"}}
     mock_recipe.seplan.aoi_model.get_ee_features.return_value = (main_features, {})
-    mock_recipe.seplan.get_benefits_list.return_value = [(Mock(), "Benefit 1")]
-    mock_recipe.seplan.get_costs_list.return_value = [(Mock(), "Cost 1")]
+    mock_recipe.seplan.get_benefits_list.return_value = [(_img(), "Benefit 1")]
+    mock_recipe.seplan.get_costs_list.return_value = [(_img(), "Cost 1")]
     mock_recipe.seplan.get_masked_constraints_list.return_value = [
-        (Mock(), "Constraint 1")
+        (_img(), "Constraint 1")
     ]
 
     mock_gee_interface = Mock()

--- a/tests/test_custom_aoi_tile.py
+++ b/tests/test_custom_aoi_tile.py
@@ -1,27 +1,23 @@
 from component.message import cm
-from component.tile.custom_aoi_tile import AoiTile
+from component.tile.custom_aoi_tile import AoiView
 
 
-def test_aoi_tile(empty_recipe, alert):
+def test_aoi_tile(empty_recipe):
 
     recipe = empty_recipe
-    aoi_tile = AoiTile(recipe=recipe)
+    aoi_tile = AoiView(map_=None, recipe=recipe)
 
-    # Select a lmic country
-    aoi_tile.view.model.admin = "959"
-    # the model increases the updated trait, and this trait is listened by the view
-    aoi_tile.view.model.set_object(method="ADMIN1")
-
-    # TODO: this is a wild return from this function. It should return a boolean only
-
+    # Select an LMIC country (Kenya, GAUL 2024 admin code 137). _check_lmic
+    # reads view.model.admin directly, so no set_object round-trip is needed.
+    aoi_tile.view.model.admin = "137"
     in_lmic = aoi_tile._check_lmic(None)
+    assert in_lmic is aoi_tile
+    assert recipe.seplan_aoi.aoi_lmic_valid is True
 
-    assert in_lmic == aoi_tile
-
-    # Select a non lmic country
-    aoi_tile.view.model.admin = "259"
-    aoi_tile.view.model.set_object(method="ADMIN1")
-
+    # Select a non-LMIC country (USA, GAUL 2024 admin code 220): the view flags
+    # it invalid and warns the user it is out of the provided layers' scope.
+    aoi_tile.view.model.admin = "220"
     in_lmic = aoi_tile._check_lmic(None)
-
+    assert in_lmic is aoi_tile
+    assert recipe.seplan_aoi.aoi_lmic_valid is False
     assert in_lmic.view.alert.children[0].children == [cm.aoi.not_lmic]

--- a/tests/test_custom_widgets/test_recipe_input.py
+++ b/tests/test_custom_widgets/test_recipe_input.py
@@ -21,43 +21,43 @@ def test_invalid_recipe():
     recipe_input = RecipeInput()
 
     with pytest.raises(ValidationError):
-        recipe_input.select_file(test_error_recipe_path)
+        recipe_input.validate_input({"new": str(test_error_recipe_path)})
 
-    # Check this is not empty
-    assert recipe_input.text_field_msg.error_messages
+    # The error is surfaced on the file input
+    assert recipe_input.file_input.error_messages
 
-    # Check value is not valid
+    # and the recipe is not accepted
     assert recipe_input.valid is False
     assert recipe_input.load_recipe_path is None
 
 
 def test_valid_recipe():
-    """Test the validation of an invalid recipe."""
+    """Test the validation of a valid recipe."""
 
     recipe_input = RecipeInput()
-    recipe_input.select_file(str(test_recipe_path))
+    recipe_input.validate_input({"new": str(test_recipe_path)})
 
-    # Check this is not empty
-    assert not recipe_input.text_field_msg.error_messages
+    # No error is surfaced
+    assert not recipe_input.file_input.error_messages
 
-    # Check value is not valid
+    # and the recipe is accepted
     assert recipe_input.valid
     assert recipe_input.load_recipe_path == str(test_recipe_path)
 
 
 def test_valid_and_invalid_recipe():
-    """Test the validation of an invalid recipe."""
+    """Test loading a valid recipe followed by an invalid one."""
 
     recipe_input = RecipeInput()
-    recipe_input.select_file(str(test_recipe_path))
+    recipe_input.validate_input({"new": str(test_recipe_path)})
 
     # Now we load an invalid recipe
     with pytest.raises(ValidationError):
-        recipe_input.select_file(test_error_recipe_path)
+        recipe_input.validate_input({"new": str(test_error_recipe_path)})
 
-    # Check this is not empty
-    assert recipe_input.text_field_msg.error_messages
+    # The error is surfaced on the file input
+    assert recipe_input.file_input.error_messages
 
-    # Check value is not valid
+    # and the previously valid state is cleared
     assert recipe_input.valid is False
     assert recipe_input.load_recipe_path is None


### PR DESCRIPTION
## Why

CI on `main` has been red. It looked like one stale test, but the failure was a **collection-time ImportError** (`test_custom_aoi_tile` importing the renamed `AoiTile`), which aborts the entire pytest run before anything executes — masking **15 more pre-existing failures**. This greens the whole suite.

Local result: **88 passed** (was 16 failed / 72 passed).

## Fixes

1. **`test_custom_aoi_tile`** — `AoiTile` → `AoiView`; the constructor now requires `map_` (pass `None`); dropped the unneeded `set_object` round-trip (`_check_lmic` reads `view.model.admin` directly); replaced stale codes `959`/`259` with valid GAUL 2024 codes (Kenya `137` = LMIC, USA `220` = non-LMIC — `959` no longer exists and `259` is now Oman/LMIC after the GAUL 2024 migration).
2. **`test_recipe_input`** (×3) — `RecipeInput.select_file` was removed; drive `validate_input({"new": path})` and read errors off `file_input.error_messages` (the old `text_field_msg` is gone). Invalid recipes still raise `ValidationError`.
3. **`test_batched_fallback`** (×4) — the statistics code builds a **lazy ee graph** from the layer inputs before the (mocked) `get_info_async`, so `Mock()` objects fail `ee.Image(...)`. Use real lightweight ee objects (`ee.Image(1)` / a real `FeatureCollection`), mirroring the passing `test_statistics_integration`. No network — `get_info_async` stays mocked.
4. **pytest-asyncio** — added to the `dev` extra with `asyncio_mode = "auto"`, so the `@pytest.mark.asyncio` tests in `test_statistics_integration` (×9) and `test_batched_fallback` run instead of failing as "async def not natively supported".

## Verification

`pytest tests/` locally: **88 passed**. The async tests exercise real GEE (EE creds present); the batched-fallback ee graphs construct without network.
