### PR TITLE
fix: support large/dense AOIs past Earth Engine's 2M-edge limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,11 @@ yarn.lock
 # Local-only docs and instructions
 docs/presentations/
 CLAUDE.md
+docs/superpowers/
+.github/instructions/
+
+# Local-only tooling and sync artifacts
+.claude/
+.stfolder/
+.stignore
+.stignore.local

--- a/component/message/en/locale.json
+++ b/component/message/en/locale.json
@@ -46,6 +46,8 @@
 	},
 	"aoi": {
 		"not_lmic": "The country you are about to use is out of the scope of the provided layers. Please note that you'll need to customize all the layers before computing the restauration suitability index. Refer to the documentation for more information",
+		"partial_lmic": "Only {}% of your area of interest falls within a low- or middle-income country covered by the default layers. You can continue, but the default layers may not be appropriate outside that area — consider customizing them before computing the restoration suitability index. Refer to the documentation for more information",
+		"lmic_check_failed": "We couldn't verify whether your area of interest is within the scope of the provided layers (the coverage check failed). You can continue, but results may be unreliable; re-select the area to run the check again",
 		"aoi_title" : "Area of interest selection"
 	}
 }

--- a/component/model/aoi_model.py
+++ b/component/model/aoi_model.py
@@ -8,7 +8,6 @@ from typing import Any as AnyType
 from typing import Dict as DictType
 from typing import Tuple
 
-import ee
 import geopandas as gpd
 import pygaul
 from sepal_ui import color, model
@@ -19,6 +18,7 @@ from sepal_ui.scripts.gee_interface import GEEInterface
 from traitlets import Any, Bool, Dict, Int
 
 import component.parameter as cp
+from component.scripts.aoi_geometry import _aoi_bbox
 
 logger = logging.getLogger("SEPLAN")
 
@@ -276,11 +276,8 @@ class AoiModel(AoiModel):
         if self.feature_collection is None:
             raise ValueError(ms.aoi_sel.exception.no_gdf)
 
-        boxes = self.feature_collection.map(
-            lambda feat: ee.Feature(feat.geometry().bounds())
-        )
         coords = await self.gee_interface.get_info_async(
-            boxes.geometry().bounds().coordinates().get(0)
+            _aoi_bbox(self.feature_collection).coordinates().get(0)
         )
         bounds = [coords[0][0], coords[0][1], coords[2][0], coords[2][1]]
         return [round(bound, 4) for bound in bounds]

--- a/component/model/aoi_model.py
+++ b/component/model/aoi_model.py
@@ -266,12 +266,9 @@ class AoiModel(AoiModel):
     async def total_bounds_async(self):
         """Return the AOI extent ``[minx, miny, maxx, maxy]`` asynchronously.
 
-        pysepal's sync ``total_bounds`` dissolves the whole feature collection
-        (``Collection.geometry``), which exceeds EE's 2M-edge limit for dense
-        GAUL 2024 boundaries (Indonesia is ~2.4M edges). Reduce each feature to
-        its bounding box first, then take the extent of those small boxes — same
-        result, no full-coastline union — and fetch it through ``get_info_async``
-        so the Solara kernel thread never blocks.
+        Uses per-feature bounding boxes (see ``_aoi_bbox``) rather than the
+        dissolved collection geometry, which can exceed EE's 2M-edge limit for
+        dense AOIs. Fetched via ``get_info_async`` so the kernel never blocks.
         """
         if self.feature_collection is None:
             raise ValueError(ms.aoi_sel.exception.no_gdf)

--- a/component/model/aoi_model.py
+++ b/component/model/aoi_model.py
@@ -4,7 +4,9 @@ import json
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import Tuple, Dict as DictType, Any as AnyType
+from typing import Any as AnyType
+from typing import Dict as DictType
+from typing import Tuple
 
 import geopandas as gpd
 import pygaul
@@ -13,7 +15,7 @@ from sepal_ui.aoi.aoi_model import AoiModel
 from sepal_ui.message import ms
 from sepal_ui.scripts import utils as su
 from sepal_ui.scripts.gee_interface import GEEInterface
-from traitlets import Bool, Dict, Int, Any
+from traitlets import Any, Bool, Dict, Int
 
 import component.parameter as cp
 
@@ -414,10 +416,18 @@ class SeplanAoi(model.Model):
     """int: this trait will be updated every time the aoi_model is updated"""
 
     aoi_lmic_valid = Bool(True).tag(sync=True)
-    """bool: True when the current AOI overlaps the LMIC mask. Defaults True
-    so a fresh app (no AOI yet) doesn't disable the right-panel actions
-    pre-emptively. Updated by ``custom_aoi_tile.AoiView._check_lmic`` after
-    each AOI change."""
+    """bool: "may proceed" flag gating the right-panel actions. True when the
+    AOI is at least partially within the LMIC scope (majority or partial
+    coverage, or an unverifiable AOI); False only when the AOI is entirely
+    out of scope. Defaults True so a fresh app (no AOI yet) doesn't disable
+    the right-panel actions pre-emptively. Updated by
+    ``custom_aoi_tile.AoiView._check_lmic`` after each AOI change."""
+
+    aoi_lmic_warning = Bool(False).tag(sync=True)
+    """bool: True when the AOI is only partially in scope or the coverage
+    check could not be completed. The AOI is still usable (``aoi_lmic_valid``
+    stays True) but the AOI step dialog stays open so the user reads the
+    warning. False for a clean (majority-LMIC) or fully out-of-scope verdict."""
 
     aoi_lmic_checked = Int(0).tag(sync=True)
     """int: counter that increments every time the LMIC verdict is settled

--- a/component/model/aoi_model.py
+++ b/component/model/aoi_model.py
@@ -8,6 +8,7 @@ from typing import Any as AnyType
 from typing import Dict as DictType
 from typing import Tuple
 
+import ee
 import geopandas as gpd
 import pygaul
 from sepal_ui import color, model
@@ -261,6 +262,28 @@ class AoiModel(AoiModel):
         self.updated += 1
 
         return self
+
+    async def total_bounds_async(self):
+        """Return the AOI extent ``[minx, miny, maxx, maxy]`` asynchronously.
+
+        pysepal's sync ``total_bounds`` dissolves the whole feature collection
+        (``Collection.geometry``), which exceeds EE's 2M-edge limit for dense
+        GAUL 2024 boundaries (Indonesia is ~2.4M edges). Reduce each feature to
+        its bounding box first, then take the extent of those small boxes — same
+        result, no full-coastline union — and fetch it through ``get_info_async``
+        so the Solara kernel thread never blocks.
+        """
+        if self.feature_collection is None:
+            raise ValueError(ms.aoi_sel.exception.no_gdf)
+
+        boxes = self.feature_collection.map(
+            lambda feat: ee.Feature(feat.geometry().bounds())
+        )
+        coords = await self.gee_interface.get_info_async(
+            boxes.geometry().bounds().coordinates().get(0)
+        )
+        bounds = [coords[0][0], coords[0][1], coords[2][0], coords[2][1]]
+        return [round(bound, 4) for bound in bounds]
 
     def clear_attributes(self):
         """Return all attributes to their default state.

--- a/component/model/recipe.py
+++ b/component/model/recipe.py
@@ -1,20 +1,19 @@
+import copy
+import logging
 from datetime import datetime
-from typing import Union
-from component.scripts.file_handler import save_file
 from pathlib import Path
 
-from sepal_ui.scripts.warning import SepalWarning
 from sepal_ui.scripts.gee_interface import GEEInterface
-from traitlets import HasTraits, Int, Unicode, observe, List as TraitsList
+from sepal_ui.scripts.warning import SepalWarning
+from traitlets import HasTraits, Int, Unicode, observe
 
 import component.parameter as cp
 from component import model as cmod
 from component.message import cm
 from component.model.aoi_model import SeplanAoi
 from component.scripts import validation
+from component.scripts.file_handler import save_file
 from component.scripts.seplan import Seplan
-
-import logging
 
 logger = logging.getLogger("SEPLAN")
 
@@ -212,6 +211,14 @@ class Recipe(HasTraits):
             "costs": self.cost_model.export_data(),
         }
 
+        # export_data() hands back each model's live ``_trait_values`` mapping,
+        # so the assembled dict aliases live state. Snapshot it before returning:
+        # callers (save, the header inspector) must get an independent copy, or
+        # later edits mutate the dict in place — which leaks stale data into the
+        # inspector preview and lets remove_key() below delete keys out of the
+        # live models.
+        data = copy.deepcopy(data)
+
         for key in ("updated", "new_changes", "object_set"):
             validation.remove_key(data, key)
 
@@ -251,7 +258,6 @@ class Recipe(HasTraits):
 
     def get_recipe_path(self, recipe_name: str):
         """generate full recipe path."""
-
         if self.sepal_session:
             recipe_dir = self.sepal_session.get_remote_dir(
                 "module_results/se.plan/recipes"

--- a/component/parameter/file_params.py
+++ b/component/parameter/file_params.py
@@ -6,6 +6,12 @@ layer_list = Path(__file__).parents[2] / "utils" / "layer_list.csv"
 # list of the lmic countries
 country_list = Path(__file__).parents[2] / "utils" / "lmic_countries.csv"
 
+# Minimum fraction of an AOI that must fall on LMIC land for the raster-based
+# (ASSET/DRAW/SHAPE) check to consider it in scope. 0.5 == majority-LMIC.
+# Replaces an older "100% coverage" gate that false-flagged whole LMIC
+# countries (e.g. Indonesia, 99.999% LMIC) over a handful of 1 km coastline px.
+MIN_LMIC_COVERAGE = 0.5
+
 # recipe schema
 recipe_schema_path = Path(__file__).parents[2] / "utils" / "recipe_schema.json"
 

--- a/component/scripts/aoi_geometry.py
+++ b/component/scripts/aoi_geometry.py
@@ -1,13 +1,9 @@
 """AOI geometry helpers that avoid EE's 2M-edge ``Collection.geometry`` limit.
 
-``ee.FeatureCollection.geometry()`` aggregates every feature into a single
-geometry; for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges) that
-exceeds EE's hard 2,000,000-edge limit. The helpers here materialise only
-per-feature bounding boxes instead, so they stay under the cap regardless of
-AOI density.
-
-Kept dependency-free (only ``ee``) so every module can import it at the top
-level — no circular-import gymnastics.
+``ee.FeatureCollection.geometry()`` aggregates every feature into one geometry,
+which can exceed EE's 2M-edge limit for dense AOIs. These helpers materialise
+only per-feature bounding boxes, so they stay under the cap. Kept dependency-free
+(only ``ee``) so every module can import them at the top level.
 """
 
 from typing import Union
@@ -18,12 +14,10 @@ import ee
 def _aoi_bbox(aoi: Union[ee.FeatureCollection, ee.Geometry]) -> ee.Geometry:
     """Bounding-box geometry for ``reduceRegion`` that never dissolves the AOI.
 
-    ``aoi.geometry()`` unions every feature (``Collection.geometry``) and exceeds
-    EE's 2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M
-    edges). The per-feature bbox merge is a cheap stand-in; callers clip the
-    image to ``aoi`` first so only AOI pixels are reduced (a clipped reduction
-    over this box matches reducing over the exact polygon — verified to the
-    sub-pixel — without ever materialising the union).
+    ``aoi.geometry()`` unions every feature and can exceed EE's 2M-edge limit on
+    dense AOIs. Take each feature's bbox first; callers clip the image to ``aoi``
+    so only AOI pixels are reduced (the result matches reducing over the exact
+    polygon).
     """
     fc = ee.FeatureCollection(aoi)
     return fc.map(lambda feat: ee.Feature(feat.geometry().bounds())).geometry().bounds()

--- a/component/scripts/aoi_geometry.py
+++ b/component/scripts/aoi_geometry.py
@@ -1,0 +1,29 @@
+"""AOI geometry helpers that avoid EE's 2M-edge ``Collection.geometry`` limit.
+
+``ee.FeatureCollection.geometry()`` aggregates every feature into a single
+geometry; for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges) that
+exceeds EE's hard 2,000,000-edge limit. The helpers here materialise only
+per-feature bounding boxes instead, so they stay under the cap regardless of
+AOI density.
+
+Kept dependency-free (only ``ee``) so every module can import it at the top
+level — no circular-import gymnastics.
+"""
+
+from typing import Union
+
+import ee
+
+
+def _aoi_bbox(aoi: Union[ee.FeatureCollection, ee.Geometry]) -> ee.Geometry:
+    """Bounding-box geometry for ``reduceRegion`` that never dissolves the AOI.
+
+    ``aoi.geometry()`` unions every feature (``Collection.geometry``) and exceeds
+    EE's 2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M
+    edges). The per-feature bbox merge is a cheap stand-in; callers clip the
+    image to ``aoi`` first so only AOI pixels are reduced (a clipped reduction
+    over this box matches reducing over the exact polygon — verified to the
+    sub-pixel — without ever materialising the union).
+    """
+    fc = ee.FeatureCollection(aoi)
+    return fc.map(lambda feat: ee.Feature(feat.geometry().bounds())).geometry().bounds()

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -51,9 +51,16 @@ async def get_layer_min_max(
     Returns:
         A ``(min, max)`` tuple rounded to two decimals.
     """
-    reduced = image.clip(aoi.geometry()).reduceRegion(
+    # Clip to the AOI + reduce over its bounding box. aoi.geometry() would
+    # dissolve the whole collection (Collection.geometry) and blow EE's 2M-edge
+    # limit for dense GAUL 2024 boundaries (e.g. Indonesia). Imported here to
+    # avoid a module-level import cycle with seplan.
+    from component.scripts.seplan import _aoi_bbox
+
+    clipped = image.clip(aoi)
+    reduced = clipped.reduceRegion(
         reducer=ee.Reducer.minMax(),
-        geometry=aoi.geometry(),
+        geometry=_aoi_bbox(aoi),
         scale=1,
         maxPixels=int(1e5),
         bestEffort=True,
@@ -343,9 +350,15 @@ async def get_limits_async(
     # If scale is less than 30, set it to 30
     scale = ee.Algorithms.If(scale.lt(30), 30, scale)
 
-    reduction = ee_image.reduceRegion(
+    # Clip to the AOI + reduce over its bbox; geometry=aoi would dissolve the
+    # whole collection (Collection.geometry) and blow EE's 2M-edge limit for
+    # dense GAUL 2024 boundaries (e.g. Indonesia). Imported here to avoid a
+    # module-level import cycle with seplan.
+    from component.scripts.seplan import _aoi_bbox
+
+    reduction = ee_image.clip(aoi).reduceRegion(
         reducer=reducer,
-        geometry=aoi,
+        geometry=_aoi_bbox(aoi),
         scale=scale,
         maxPixels=1e13,
     )

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -356,11 +356,15 @@ async def get_limits_async(
     # module-level import cycle with seplan.
     from component.scripts.seplan import _aoi_bbox
 
+    # bestEffort + a capped maxPixels coarsens the scale for big AOIs (e.g.
+    # Indonesia at 30 m would take ~2 min otherwise) — an approximate range is
+    # fine for the slider; small AOIs stay under the cap and remain exact.
     reduction = ee_image.clip(aoi).reduceRegion(
         reducer=reducer,
         geometry=_aoi_bbox(aoi),
         scale=scale,
-        maxPixels=1e13,
+        bestEffort=True,
+        maxPixels=1e8,
     )
 
     values = await get_value_async(reduction)

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -277,14 +277,16 @@ async def get_limits_async(
     scale = ee.Algorithms.If(scale.lt(30), 30, scale)
 
     # Clip to the AOI + reduce over its bbox to avoid dissolving the collection.
-    # bestEffort + a capped maxPixels coarsens the scale for big AOIs (an
-    # approximate range is fine for the slider; small AOIs stay exact).
+    # Only continuous range sliders tolerate coarsening (bestEffort + a capped
+    # maxPixels speeds up big AOIs); binary/categorical value discovery stays
+    # exact so rare values present in the AOI aren't dropped from the choices.
+    coarsen = data_type == "continuous"
     reduction = ee_image.clip(aoi).reduceRegion(
         reducer=reducer,
         geometry=_aoi_bbox(aoi),
         scale=scale,
-        bestEffort=True,
-        maxPixels=1e8,
+        bestEffort=coarsen,
+        maxPixels=1e8 if coarsen else 1e13,
     )
 
     values = await get_value_async(reduction)

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -11,6 +11,7 @@ from sepal_ui.scripts.gee_interface import GEEInterface
 
 from component import parameter as cp
 from component.message import cm
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.scripts.assets import default_asset_id
 
 logger = logging.getLogger("SEPLAN")
@@ -53,10 +54,7 @@ async def get_layer_min_max(
     """
     # Clip to the AOI + reduce over its bounding box. aoi.geometry() would
     # dissolve the whole collection (Collection.geometry) and blow EE's 2M-edge
-    # limit for dense GAUL 2024 boundaries (e.g. Indonesia). Imported here to
-    # avoid a module-level import cycle with seplan.
-    from component.scripts.seplan import _aoi_bbox
-
+    # limit for dense GAUL 2024 boundaries (e.g. Indonesia).
     clipped = image.clip(aoi)
     reduced = clipped.reduceRegion(
         reducer=ee.Reducer.minMax(),
@@ -225,77 +223,6 @@ def get_layer(
     )
 
 
-def get_limits(
-    gee_interface: GEEInterface,
-    asset: str,
-    data_type: Literal["binary", "continuous", "categorical"],
-    aoi: Union[ee.FeatureCollection, ee.Geometry],
-    factor: int = 2,
-) -> List[int]:
-    """Computes limits or histogram keys for the given Earth Engine image based on the specified data type.
-
-    Args:
-        gee_interface (GEEInterface): The interface used to run Earth Engine operations.
-        asset (str): Google Earth Engine asset ID.
-        data_type (str): Either 'binary', 'continuous', or any other type indicating the type of data processing.
-        aoi (ee.Geometry): Area of interest.
-        factor (int, optional): Factor to multiply the nominal scale of the image. Defaults to 2 (i.e. 2x the nominal scale
-
-    Returns:
-        list: A list containing either min-max values or histogram keys depending on the data_type.
-    """
-    # We know that the treecover_with_potential asset is binary
-    if asset == default_asset_id:
-        return [0, 1]
-
-    if data_type in ["binary", "continuous"]:
-        reducer = ee.Reducer.minMax()
-
-        def get_value(reduction):
-            return list(gee_interface.get_info(reduction).values())
-
-    else:
-        reducer = ee.Reducer.frequencyHistogram()
-
-        def get_value(reduction):
-            return gee_interface.get_info(
-                ee.Dictionary(reduction.get(ee.Image(asset).bandNames().get(0))).keys(),
-            )
-
-    ee_image = ee.Image(asset).select(0)
-    # Multiply the nominal scale by 2 in case the nominal scale is finer than 45
-    scale = ee.Number(
-        ee.Algorithms.If(
-            ee_image.projection().nominalScale().lt(30),
-            ee_image.projection().nominalScale().multiply(2),
-            ee_image.projection().nominalScale(),
-        )
-    )
-
-    # If scale is less than 30, set it to 30
-    scale = ee.Algorithms.If(scale.lt(30), 30, scale)
-
-    values = get_value(
-        ee_image.reduceRegion(
-            reducer=reducer,
-            geometry=aoi,
-            scale=scale,
-            maxPixels=1e13,
-        )
-    )
-
-    logger.debug(f"get_limits_values: {values}")
-
-    # check if values are none and if so, raise a ValueError
-    if any([val is None for val in values]):
-        raise ValueError(cm.questionnaire.error.no_limits)
-
-    # depending on the scale, values from the histogram can be floats, we'll
-    # convert them to integers... sometimes we'll show more values than the
-    # asset really has
-    return sorted(set(int(float(val)) for val in values))
-
-
 async def get_limits_async(
     gee_interface: GEEInterface,
     asset: str,
@@ -352,10 +279,7 @@ async def get_limits_async(
 
     # Clip to the AOI + reduce over its bbox; geometry=aoi would dissolve the
     # whole collection (Collection.geometry) and blow EE's 2M-edge limit for
-    # dense GAUL 2024 boundaries (e.g. Indonesia). Imported here to avoid a
-    # module-level import cycle with seplan.
-    from component.scripts.seplan import _aoi_bbox
-
+    # dense GAUL 2024 boundaries (e.g. Indonesia).
     # bestEffort + a capped maxPixels coarsens the scale for big AOIs (e.g.
     # Indonesia at 30 m would take ~2 min otherwise) — an approximate range is
     # fine for the slider; small AOIs stay under the cap and remain exact.

--- a/component/scripts/gee.py
+++ b/component/scripts/gee.py
@@ -52,9 +52,8 @@ async def get_layer_min_max(
     Returns:
         A ``(min, max)`` tuple rounded to two decimals.
     """
-    # Clip to the AOI + reduce over its bounding box. aoi.geometry() would
-    # dissolve the whole collection (Collection.geometry) and blow EE's 2M-edge
-    # limit for dense GAUL 2024 boundaries (e.g. Indonesia).
+    # Clip to the AOI + reduce over its bbox; reducing over aoi.geometry()
+    # would dissolve the collection and can exceed EE's 2M-edge limit.
     clipped = image.clip(aoi)
     reduced = clipped.reduceRegion(
         reducer=ee.Reducer.minMax(),
@@ -277,12 +276,9 @@ async def get_limits_async(
     # If scale is less than 30, set it to 30
     scale = ee.Algorithms.If(scale.lt(30), 30, scale)
 
-    # Clip to the AOI + reduce over its bbox; geometry=aoi would dissolve the
-    # whole collection (Collection.geometry) and blow EE's 2M-edge limit for
-    # dense GAUL 2024 boundaries (e.g. Indonesia).
-    # bestEffort + a capped maxPixels coarsens the scale for big AOIs (e.g.
-    # Indonesia at 30 m would take ~2 min otherwise) — an approximate range is
-    # fine for the slider; small AOIs stay under the cap and remain exact.
+    # Clip to the AOI + reduce over its bbox to avoid dissolving the collection.
+    # bestEffort + a capped maxPixels coarsens the scale for big AOIs (an
+    # approximate range is fine for the slider; small AOIs stay exact).
     reduction = ee_image.clip(aoi).reduceRegion(
         reducer=reducer,
         geometry=_aoi_bbox(aoi),

--- a/component/scripts/seplan.py
+++ b/component/scripts/seplan.py
@@ -7,6 +7,7 @@ import ee
 from component import model as cmod
 from component.message import cm
 from component.model.aoi_model import SeplanAoi
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.scripts.validation import validate_mask_image_parameters
 
 
@@ -166,20 +167,6 @@ def reduce_constraints(masked_constraints_list: List[Tuple[ee.Image, str]]) -> e
     """Reduce constraints list and returns one image masked."""
     constraints = [constraint for constraint, _ in masked_constraints_list]
     return ee.Image(constraints).mask().reduce(ee.Reducer.min()).gt(0).selfMask()
-
-
-def _aoi_bbox(aoi: Union[ee.FeatureCollection, ee.Geometry]) -> ee.Geometry:
-    """Bounding-box geometry for ``reduceRegion`` that never dissolves the AOI.
-
-    ``aoi.geometry()`` unions every feature (``Collection.geometry``) and exceeds
-    EE's 2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M
-    edges). The per-feature bbox merge is a cheap stand-in; callers clip the
-    image to ``aoi`` first so only AOI pixels are reduced (a clipped reduction
-    over this box matches reducing over the exact polygon — verified to the
-    sub-pixel — without ever materialising the union).
-    """
-    fc = ee.FeatureCollection(aoi)
-    return fc.map(lambda feat: ee.Feature(feat.geometry().bounds())).geometry().bounds()
 
 
 def _percentile(

--- a/component/scripts/seplan.py
+++ b/component/scripts/seplan.py
@@ -142,7 +142,6 @@ def mask_image(
     maskout_values: list,
 ) -> ee.Image:
     """Mask out an image based on its data type and input values."""
-
     # Validate parameters using centralized validation
     validate_mask_image_parameters(asset_id, data_type, maskout_values)
 
@@ -169,6 +168,20 @@ def reduce_constraints(masked_constraints_list: List[Tuple[ee.Image, str]]) -> e
     return ee.Image(constraints).mask().reduce(ee.Reducer.min()).gt(0).selfMask()
 
 
+def _aoi_bbox(aoi: Union[ee.FeatureCollection, ee.Geometry]) -> ee.Geometry:
+    """Bounding-box geometry for ``reduceRegion`` that never dissolves the AOI.
+
+    ``aoi.geometry()`` unions every feature (``Collection.geometry``) and exceeds
+    EE's 2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M
+    edges). The per-feature bbox merge is a cheap stand-in; callers clip the
+    image to ``aoi`` first so only AOI pixels are reduced (a clipped reduction
+    over this box matches reducing over the exact polygon — verified to the
+    sub-pixel — without ever materialising the union).
+    """
+    fc = ee.FeatureCollection(aoi)
+    return fc.map(lambda feat: ee.Feature(feat.geometry().bounds())).geometry().bounds()
+
+
 def _percentile(
     ee_image: ee.Image,
     aoi: ee.FeatureCollection,
@@ -177,10 +190,12 @@ def _percentile(
 ) -> ee.Image:
     """Return a normalized version of the layer image."""
     ee_image = ee_image.select(0)
-    percents = ee_image.rename("img").reduceRegion(
+    clipped = ee_image.rename("img").clip(aoi)
+    percents = clipped.reduceRegion(
         reducer=ee.Reducer.percentile(percentiles=percentile),
-        geometry=aoi.geometry(),
+        geometry=_aoi_bbox(aoi),
         scale=scale,
+        maxPixels=1e13,
     )
     low = ee.Number(percents.get(f"img_p{percentile[0]}"))
     high = ee.Number(percents.get(f"img_p{percentile[1]}")).add(0.1e-13)
@@ -195,8 +210,12 @@ def _min_max(
 ) -> ee.Image:
     """Return a normalized version of the layer image."""
     ee_image = ee_image.select(0)
-    min_max = ee_image.rename("img").reduceRegion(
-        reducer=ee.Reducer.minMax(), geometry=aoi.geometry(), scale=scale
+    clipped = ee_image.rename("img").clip(aoi)
+    min_max = clipped.reduceRegion(
+        reducer=ee.Reducer.minMax(),
+        geometry=_aoi_bbox(aoi),
+        scale=scale,
+        maxPixels=1e13,
     )
     low = ee.Number(min_max.get("img_min"))
     high = ee.Number(min_max.get("img_max")).add(0.1e-13)
@@ -248,9 +267,10 @@ def quintiles(
     # ee_image.projection().nominalScale().multiply(2)
 
     band_name = ee.String(ee_image.bandNames().get(0))
-    quintiles_dict = ee_image.reduceRegion(
+    clipped = ee_image.clip(ee_aoi)
+    quintiles_dict = clipped.reduceRegion(
         reducer=ee.Reducer.percentile(percentiles=[20, 40, 60, 80]),
-        geometry=ee_aoi,
+        geometry=_aoi_bbox(ee_aoi),
         tileScale=2,
         scale=100,
         maxPixels=1e13,

--- a/component/scripts/statistics.py
+++ b/component/scripts/statistics.py
@@ -26,11 +26,9 @@ CSV export reads this constant to report the actual computation scale."""
 def _reduce_region_aoi(image: ee.Image, aoi, **reduce_kwargs) -> ee.Dictionary:
     """``reduceRegion`` over an AOI without dissolving it.
 
-    ``geometry=aoi`` unions every feature (``Collection.geometry``) and exceeds
-    EE's 2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M
-    edges). Clip the image to the AOI and reduce over its bounding box — masked
-    pixels don't contribute, so the result matches reducing over the exact
-    polygon (verified to within a pixel for both area and percentiles).
+    Reducing over ``aoi.geometry()`` can exceed EE's 2M-edge limit for dense
+    AOIs. Clip the image to the AOI and reduce over its bounding box instead —
+    masked pixels don't contribute, so the result matches the exact polygon.
     """
     return image.clip(aoi).reduceRegion(geometry=_aoi_bbox(aoi), **reduce_kwargs)
 

--- a/component/scripts/statistics.py
+++ b/component/scripts/statistics.py
@@ -6,7 +6,8 @@ import ee
 from sepal_ui.scripts.gee_interface import GEEInterface
 
 from component.model.recipe import Recipe
-from component.scripts.seplan import _aoi_bbox, reduce_constraints
+from component.scripts.aoi_geometry import _aoi_bbox
+from component.scripts.seplan import reduce_constraints
 from component.types import (
     MeanStatsDict,
     MeanStatsValues,

--- a/component/scripts/statistics.py
+++ b/component/scripts/statistics.py
@@ -1,11 +1,12 @@
-from typing import Dict, List, Union
-import logging
 import asyncio
+import logging
+from typing import Dict
+
 import ee
 from sepal_ui.scripts.gee_interface import GEEInterface
 
 from component.model.recipe import Recipe
-from component.scripts.seplan import reduce_constraints
+from component.scripts.seplan import _aoi_bbox, reduce_constraints
 from component.types import (
     MeanStatsDict,
     MeanStatsValues,
@@ -19,6 +20,18 @@ logger = logging.getLogger("SEPLAN")
 STATS_SCALE_M = 100
 """Scale (in meters) used by every reduceRegion in this module. The dashboard
 CSV export reads this constant to report the actual computation scale."""
+
+
+def _reduce_region_aoi(image: ee.Image, aoi, **reduce_kwargs) -> ee.Dictionary:
+    """``reduceRegion`` over an AOI without dissolving it.
+
+    ``geometry=aoi`` unions every feature (``Collection.geometry``) and exceeds
+    EE's 2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M
+    edges). Clip the image to the AOI and reduce over its bounding box — masked
+    pixels don't contribute, so the result matches reducing over the exact
+    polygon (verified to within a pixel for both area and percentiles).
+    """
+    return image.clip(aoi).reduceRegion(geometry=_aoi_bbox(aoi), **reduce_kwargs)
 
 
 def is_main_aoi(main_aoi_name, aoi_name) -> bool:
@@ -71,7 +84,6 @@ async def _get_summary_statistics_sequential(
     Processes each AOI sequentially to avoid overwhelming GEE with concurrent operations.
     This is the primary method that should work for most cases.
     """
-
     if not recipe:
         raise ValueError("There is no recipe to get statistics from.")
 
@@ -171,7 +183,6 @@ async def _get_summary_statistics_batched(
     Returns:
         RecipeStatsDict with all computed statistics
     """
-
     if not recipe:
         raise ValueError("There is no recipe to get statistics from.")
 
@@ -365,18 +376,14 @@ def get_image_stats(image, mask, geom):
 
     image = image.rename("image").round()
 
-    areas = (
-        ee.Image.pixelArea()
-        .divide(10000)
-        .addBands(image)
-        .reduceRegion(
-            reducer=ee.Reducer.sum().group(1, "image"),
-            geometry=geom,
-            scale=STATS_SCALE_M,
-            maxPixels=1e12,
-        )
-        .get("groups")
-    )
+    composite = ee.Image.pixelArea().divide(10000).addBands(image)
+    areas = _reduce_region_aoi(
+        composite,
+        geom,
+        reducer=ee.Reducer.sum().group(1, "image"),
+        scale=STATS_SCALE_M,
+        maxPixels=1e12,
+    ).get("groups")
 
     areas_list = ee.List(areas).map(lambda i: ee.Dictionary(i).get("sum"))
     total = areas_list.reduce(ee.Reducer.sum())
@@ -393,18 +400,14 @@ def get_image_percent_cover_pixelarea(
     # Be sure the mask is 0
     image = image.rename("image").unmask(0)
 
-    areas = (
-        ee.Image.pixelArea()
-        .divide(10000)
-        .addBands(image)
-        .reduceRegion(
-            reducer=ee.Reducer.sum().group(1, "image"),
-            geometry=aoi,
-            scale=STATS_SCALE_M,
-            maxPixels=1e12,
-        )
-        .get("groups")
-    )
+    composite = ee.Image.pixelArea().divide(10000).addBands(image)
+    areas = _reduce_region_aoi(
+        composite,
+        aoi,
+        reducer=ee.Reducer.sum().group(1, "image"),
+        scale=STATS_SCALE_M,
+        maxPixels=1e12,
+    ).get("groups")
     areas = ee.List(areas)
     areas_list = areas.map(lambda i: ee.Dictionary(i).get("sum"))
     total = areas_list.reduce(ee.Reducer.sum())
@@ -440,7 +443,6 @@ def get_image_mean(image, aoi, mask, name, main_aoi) -> Dict[str, MeanStatsDict]
     Note: This function has been optimized to reduce the number of reduceRegion calls
     from 2 to 1 by reusing the masked mean calculation for the total value.
     """
-
     image = image.updateMask(mask)
 
     # Set the default values for the output
@@ -462,9 +464,10 @@ def get_image_mean(image, aoi, mask, name, main_aoi) -> Dict[str, MeanStatsDict]
 
     # Single reduceRegion call instead of two
     result = result.combine(
-        image.reduceRegion(
+        _reduce_region_aoi(
+            image,
+            aoi,
             reducer=reducer,
-            geometry=aoi,
             scale=STATS_SCALE_M,
             maxPixels=1e13,
         )
@@ -485,32 +488,26 @@ def get_image_sum(image, aoi, mask, name) -> Dict[str, SumStatsDict]:
 
     returns dict name:{value:[],total:[]}.
     """
-    area_ha = (
-        ee.Image.pixelArea()
-        .divide(10000)
-        .reduceRegion(
-            reducer=ee.Reducer.sum(),
-            geometry=aoi,
-            scale=STATS_SCALE_M,
-            maxPixels=1e13,
-        )
-        .get("area")
-    )
-
-    sum_img = (
-        image.reproject("EPSG:4326")
-        .updateMask(mask)
-        .reduceRegion(
-            reducer=ee.Reducer.sum(),
-            geometry=aoi,
-            scale=STATS_SCALE_M,
-            maxPixels=1e13,
-        )
-    )
-
-    total_img = image.reduceRegion(
+    area_ha = _reduce_region_aoi(
+        ee.Image.pixelArea().divide(10000),
+        aoi,
         reducer=ee.Reducer.sum(),
-        geometry=aoi,
+        scale=STATS_SCALE_M,
+        maxPixels=1e13,
+    ).get("area")
+
+    sum_img = _reduce_region_aoi(
+        image.reproject("EPSG:4326").updateMask(mask),
+        aoi,
+        reducer=ee.Reducer.sum(),
+        scale=STATS_SCALE_M,
+        maxPixels=1e13,
+    )
+
+    total_img = _reduce_region_aoi(
+        image,
+        aoi,
+        reducer=ee.Reducer.sum(),
         scale=STATS_SCALE_M,
         maxPixels=1e13,
     )

--- a/component/tile/custom_aoi_tile.py
+++ b/component/tile/custom_aoi_tile.py
@@ -149,8 +149,7 @@ class AoiView(sw.Layout):
         # name. Keep the raster MASKED (no unmask): masked ocean/no-data is
         # excluded, so ``fraction`` is the LMIC share of the AOI's land pixels.
         # Clip to the AOI + reduce over its bbox rather than geometry=fc.geometry(),
-        # which would dissolve the whole collection and blow the 2M-edge limit on
-        # a large non-admin AOI (e.g. an uploaded dense boundary).
+        # which would dissolve the collection and can exceed the 2M-edge limit.
         lmic01 = lmic_raster.select(0).rename("lmic")
         masked = lmic01.clip(fc)
         fraction = masked.reduceRegion(

--- a/component/tile/custom_aoi_tile.py
+++ b/component/tile/custom_aoi_tile.py
@@ -1,23 +1,18 @@
-from typing import Union
+
+import logging
 
 import ee
 import pandas as pd
 import pygaul
-from component.frontend.icons import icon
-from component.widget.base_dialog import BaseDialog
-from component.widget.buttons import IconBtn, TextBtn
 import sepal_ui.sepalwidgets as sw
-from ipyleaflet import WidgetControl
 from sepal_ui.mapping import SepalMap
 from sepal_ui.scripts.gee_interface import GEEInterface
+from sepal_ui.scripts.utils import init_ee
 
 import component.parameter as cp
 from component.message import cm
 from component.model.recipe import Recipe
 from component.widget.custom_aoi_view import SeplanAoiView
-
-from sepal_ui.scripts.utils import init_ee
-import logging
 
 logger = logging.getLogger("SEPLAN")
 
@@ -73,6 +68,9 @@ class AoiView(sw.Layout):
         action-blocking can react.
         """
         seplan_aoi = self.seplan_aoi  # SeplanAoi wrapper
+        # Reset the soft-warning flag; only the partial / unverifiable verdicts
+        # below (or the async GEE path) raise it again.
+        seplan_aoi.aoi_lmic_warning = False
         if self.view.model.admin:
             logger.info("Checking if the aoi is in the LMIC country list")
             code = str(self.view.model.admin)
@@ -113,17 +111,29 @@ class AoiView(sw.Layout):
         return self
 
     def _on_gee_lmic_error(self, exc: Exception):
-        """Treat GEE check failures as 'unknown' — leave aoi_lmic_valid False.
+        """Treat GEE check failures as 'unverifiable' — warn but allow.
 
-        The user can still see the warning (logged here) but the right-panel
-        actions stay disabled until a successful re-check. Bumping the
-        counter releases any waiters (e.g. the dialog-close observer).
+        A failed heuristic shouldn't lock the user out, so the AOI stays usable
+        (``aoi_lmic_valid`` True) with a visible notice and ``aoi_lmic_warning``
+        set so the step dialog stays open. Bumping the counter releases any
+        waiters (e.g. the dialog-close observer).
         """
         logger.warning(f"LMIC check failed: {exc}")
+        self.view.alert.add_msg(cm.aoi.lmic_check_failed, "error")
+        self.seplan_aoi.aoi_lmic_valid = True
+        self.seplan_aoi.aoi_lmic_warning = True
         self.seplan_aoi.aoi_lmic_checked += 1
 
     async def _check_lmic_gee_async(self):
-        """Async LMIC overlap check for non-admin AOIs.
+        """Async, tiered LMIC coverage check for non-admin AOIs.
+
+        Computes the fraction of the AOI that falls on LMIC land and grades it:
+        ``>= cp.MIN_LMIC_COVERAGE`` passes cleanly; a smaller but non-zero share
+        is allowed with a warning (``aoi_lmic_warning``); a zero share is
+        blocked. This replaces an earlier ``bitwiseAnd`` test that required
+        *every* pixel to be LMIC — at 1 km a handful of coastline pixels (e.g.
+        ~10 of ~1.9M for Indonesia, 99.999% LMIC) collapsed the AND to 0 and
+        falsely flagged whole LMIC countries as out of scope.
 
         Drives ``get_info_async`` on the GEE event loop. Safe to launch from
         either the kernel thread or the GEE thread.
@@ -134,23 +144,53 @@ class AoiView(sw.Layout):
         )
         aoi_ee_geom = seplan_aoi.feature_collection.geometry()
 
-        empt = ee.Image().byte()
-        aoi_ee_raster = empt.paint(aoi_ee_geom, 1)
-
-        bit_test = aoi_ee_raster.add(lmic_raster).reduceRegion(
-            reducer=ee.Reducer.bitwiseAnd(),
+        # select(0)+rename so the verdict doesn't depend on the asset's band
+        # name. Keep the raster MASKED (no unmask): masked ocean/no-data is
+        # excluded, so ``fraction`` is the LMIC share of the AOI's land pixels.
+        # unmask(0) would force EE to materialise the exact AOI polygon and
+        # blow the 2M-edge limit on large countries (Indonesia's GAUL geometry
+        # has ~3.26M edges).
+        lmic01 = lmic_raster.select(0).rename("lmic")
+        fraction = lmic01.reduceRegion(
+            reducer=ee.Reducer.mean(),
             geometry=aoi_ee_geom,
             scale=1000,
             bestEffort=True,
             maxPixels=1e13,
+        ).getNumber("lmic")
+
+        # ``If(fraction, ...)`` guards against a null mean (AOI outside the
+        # raster footprint) so we always get a number back.
+        frac = await self.gee_interface.get_info_async(
+            ee.Number(ee.Algorithms.If(fraction, fraction, 0))
         )
-        # bitwiseAnd == 2 means full LMIC coverage (1 partial, 0 none).
-        included = bool(
-            await self.gee_interface.get_info_async(
-                ee.Algorithms.IsEqual(bit_test.getNumber("constant"), 2),
-            )
-        )
-        if not included:
+        self._apply_lmic_verdict(frac)
+
+    def _apply_lmic_verdict(self, frac) -> None:
+        """Grade an LMIC land-coverage fraction into a verdict + user alert.
+
+        ``frac`` is the share (0..1) of the AOI that falls on LMIC land:
+        ``>= cp.MIN_LMIC_COVERAGE`` passes cleanly; a smaller non-zero share is
+        allowed but warned (``aoi_lmic_warning`` keeps the step dialog open so
+        the notice is read); zero/None is blocked as fully out of scope.
+        Pure-Python and synchronous so it can be unit-tested without GEE.
+        """
+        seplan_aoi = self.seplan_aoi
+        frac = frac or 0.0
+        if frac <= 0:
+            # entirely out of scope → hard block.
             self.view.alert.add_msg(cm.aoi.not_lmic, "warning")
-        seplan_aoi.aoi_lmic_valid = included
+            seplan_aoi.aoi_lmic_valid = False
+            seplan_aoi.aoi_lmic_warning = False
+        elif frac < cp.MIN_LMIC_COVERAGE:
+            # partial coverage → allow, but warn and keep the dialog open.
+            self.view.alert.add_msg(
+                cm.aoi.partial_lmic.format(round(frac * 100)), "warning"
+            )
+            seplan_aoi.aoi_lmic_valid = True
+            seplan_aoi.aoi_lmic_warning = True
+        else:
+            # majority LMIC → clean pass.
+            seplan_aoi.aoi_lmic_valid = True
+            seplan_aoi.aoi_lmic_warning = False
         seplan_aoi.aoi_lmic_checked += 1

--- a/component/tile/custom_aoi_tile.py
+++ b/component/tile/custom_aoi_tile.py
@@ -12,6 +12,7 @@ from sepal_ui.scripts.utils import init_ee
 import component.parameter as cp
 from component.message import cm
 from component.model.recipe import Recipe
+from component.scripts.seplan import _aoi_bbox
 from component.widget.custom_aoi_view import SeplanAoiView
 
 logger = logging.getLogger("SEPLAN")
@@ -142,18 +143,19 @@ class AoiView(sw.Layout):
         lmic_raster = ee.Image(
             "projects/john-ee-282116/assets/fao-restoration/misc/lmic_global_1k"
         )
-        aoi_ee_geom = seplan_aoi.feature_collection.geometry()
+        fc = seplan_aoi.feature_collection
 
         # select(0)+rename so the verdict doesn't depend on the asset's band
         # name. Keep the raster MASKED (no unmask): masked ocean/no-data is
         # excluded, so ``fraction`` is the LMIC share of the AOI's land pixels.
-        # unmask(0) would force EE to materialise the exact AOI polygon and
-        # blow the 2M-edge limit on large countries (Indonesia's GAUL geometry
-        # has ~3.26M edges).
+        # Clip to the AOI + reduce over its bbox rather than geometry=fc.geometry(),
+        # which would dissolve the whole collection and blow the 2M-edge limit on
+        # a large non-admin AOI (e.g. an uploaded dense boundary).
         lmic01 = lmic_raster.select(0).rename("lmic")
-        fraction = lmic01.reduceRegion(
+        masked = lmic01.clip(fc)
+        fraction = masked.reduceRegion(
             reducer=ee.Reducer.mean(),
-            geometry=aoi_ee_geom,
+            geometry=_aoi_bbox(fc),
             scale=1000,
             bestEffort=True,
             maxPixels=1e13,

--- a/component/tile/custom_aoi_tile.py
+++ b/component/tile/custom_aoi_tile.py
@@ -12,7 +12,7 @@ from sepal_ui.scripts.utils import init_ee
 import component.parameter as cp
 from component.message import cm
 from component.model.recipe import Recipe
-from component.scripts.seplan import _aoi_bbox
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.widget.custom_aoi_view import SeplanAoiView
 
 logger = logging.getLogger("SEPLAN")

--- a/component/tile/dashboard_components.py
+++ b/component/tile/dashboard_components.py
@@ -1,5 +1,5 @@
-"""
-Individual dashboard components for the right panel stacking system.
+"""Individual dashboard components for the right panel stacking system.
+
 These replace the monolithic DashboardTile approach.
 """
 
@@ -13,9 +13,9 @@ from component import parameter as cp
 from component import widget as cw
 from component.message import cm
 from component.model.recipe import Recipe
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.scripts.compute import export_as_csv
 from component.scripts.gee import create_layer
-from component.scripts.seplan import _aoi_bbox
 from component.scripts.statistics import get_summary_statistics_async
 from component.tile.dashboard_tile import OverallDashboard, ThemeDashboard
 from component.widget.alert_state import Alert

--- a/component/tile/dashboard_components.py
+++ b/component/tile/dashboard_components.py
@@ -3,11 +3,9 @@ Individual dashboard components for the right panel stacking system.
 These replace the monolithic DashboardTile approach.
 """
 
-import logging
 import asyncio
+import logging
 
-from component.tile.dashboard_tile import OverallDashboard, ThemeDashboard
-from component.widget.custom_widgets import MapInfoDialog
 import sepal_ui.sepalwidgets as sw
 from sepal_ui.scripts.gee_interface import GEEInterface
 
@@ -16,17 +14,20 @@ from component import widget as cw
 from component.message import cm
 from component.model.recipe import Recipe
 from component.scripts.compute import export_as_csv
-from component.scripts.statistics import get_summary_statistics_async
-from component.widget.alert_state import Alert
-from component.widget.base_dialog import BaseDialog, MapDialog
-from component.widget.buttons import IconBtn, TextBtn
 from component.scripts.gee import create_layer
+from component.scripts.seplan import _aoi_bbox
+from component.scripts.statistics import get_summary_statistics_async
+from component.tile.dashboard_tile import OverallDashboard, ThemeDashboard
+from component.widget.alert_state import Alert
+from component.widget.base_dialog import MapDialog
+from component.widget.buttons import IconBtn, TextBtn
+from component.widget.custom_widgets import MapInfoDialog
 
 logger = logging.getLogger("SEPLAN")
 
 
 class MapComputeComponent(sw.Layout):
-    """Component for map computation functionality"""
+    """Component for map computation functionality."""
 
     def __init__(
         self,
@@ -109,7 +110,6 @@ class MapComputeComponent(sw.Layout):
 
     async def _get_maps(self):
         """Compute the restoration maps."""
-
         self.map_.clean_map()
 
         aoi = self.recipe.seplan_aoi.feature_collection
@@ -121,7 +121,7 @@ class MapComputeComponent(sw.Layout):
         constraint_index = self.recipe.seplan.get_constraint_index().unmask(0).clip(aoi)
 
         tasks = [
-            self.gee_interface.get_info_async(aoi.bounds().coordinates().get(0)),
+            self.gee_interface.get_info_async(_aoi_bbox(aoi).coordinates().get(0)),
             self.gee_interface.get_map_id_async(benefit_index, cp.layer_vis),
             self.gee_interface.get_map_id_async(benefit_cost_index, cp.layer_vis),
             self.gee_interface.get_map_id_async(constraint_index, cp.layer_vis),
@@ -135,7 +135,7 @@ class MapComputeComponent(sw.Layout):
 
 
 class MapDownloadComponent(sw.Layout):
-    """Component for map download functionality"""
+    """Component for map download functionality."""
 
     def __init__(self, recipe: Recipe, alert: Alert, **kwargs):
         super().__init__(**kwargs)
@@ -157,7 +157,7 @@ class MapDownloadComponent(sw.Layout):
 
 
 class DashboardDialog(MapDialog):
-    """Dialog to display the dashboard results"""
+    """Dialog to display the dashboard results."""
 
     def __init__(self, recipe, theme_toggle, **kwargs):
         super().__init__(persistent=False, **kwargs)
@@ -190,7 +190,7 @@ class DashboardDialog(MapDialog):
         ]
 
     def set_results(self, summary_stats, recipes=None):
-        """Set the results for the dashboard"""
+        """Set the results for the dashboard."""
         logger.debug(f"Setting results in DashboardDialog: {summary_stats}")
 
         if not recipes:
@@ -207,7 +207,7 @@ class DashboardDialog(MapDialog):
 
 
 class DownloadComponent(sw.Layout):
-    """Component for CSV export functionality"""
+    """Component for CSV export functionality."""
 
     def __init__(
         self, gee_interface: GEEInterface, recipe: Recipe, alert: Alert, **kwargs
@@ -227,7 +227,7 @@ class DownloadComponent(sw.Layout):
         self._configure_csv_export()
 
     def _configure_csv_export(self):
-        """Configure the CSV export functionality"""
+        """Configure the CSV export functionality."""
 
         def create_csv_task():
             def callback(*_):
@@ -253,7 +253,7 @@ class DownloadComponent(sw.Layout):
 
 
 class DashboardComputeComponent(sw.Layout):
-    """Component for dashboard computation and viewing"""
+    """Component for dashboard computation and viewing."""
 
     def __init__(
         self,
@@ -295,7 +295,7 @@ class DashboardComputeComponent(sw.Layout):
         self._configure_dashboard()
 
     def _configure_dashboard(self):
-        """Configure the dashboard computation"""
+        """Configure the dashboard computation."""
 
         def create_dashboard_task():
             def callback(*_):
@@ -319,7 +319,7 @@ class DashboardComputeComponent(sw.Layout):
         )
 
     def _open_existing_dashboard(self, *_):
-        """Open dashboard with existing results"""
+        """Open dashboard with existing results."""
         if self.summary_stats:
             self.dashboard_dialog.set_results(self.summary_stats)
 
@@ -330,13 +330,13 @@ class DashboardComputeComponent(sw.Layout):
             return
 
     def reset(self):
-        """Reset component state"""
+        """Reset component state."""
         self.summary_stats = None
         self.dashboard_dialog.close_dialog()
 
 
 class CompareComponent(sw.Layout):
-    """Component for scenario comparison"""
+    """Component for scenario comparison."""
 
     def __init__(
         self,

--- a/component/widget/custom_aoi_dialog.py
+++ b/component/widget/custom_aoi_dialog.py
@@ -26,13 +26,20 @@ _CONTAINMENT_TOLERANCE_M2 = 1.0
 def _outside_area(child: ee.Geometry, primary_fc: ee.FeatureCollection) -> ee.Number:
     """Area (m²) of ``child`` lying outside the primary AOI.
 
-    Differences only against the primary features the child overlaps
-    (``filterBounds``); ``primary_fc.geometry()`` would union the whole
-    collection and can exceed EE's 2M-edge limit on dense AOIs. Stays
-    vector-exact, so the sub-m² tolerance above is preserved.
+    Sums per-feature covered area instead of differencing against the union of
+    the overlapping features: a sub-AOI spanning a dense primary would otherwise
+    rebuild the whole multi-million-edge collection and exceed EE's 2M-edge
+    limit. Admin features are disjoint, so covered area is the sum of per-feature
+    intersections; this stays vector-exact (the sub-m² tolerance is preserved).
     """
     nearby = primary_fc.filterBounds(child)
-    return child.difference(nearby.geometry(), maxError=1).area()
+    with_area = nearby.map(
+        lambda feat: feat.set(
+            "_a", child.intersection(feat.geometry(), maxError=1).area(maxError=1)
+        )
+    )
+    covered = with_area.aggregate_sum("_a")
+    return child.area(maxError=1).subtract(covered)
 
 
 class CustomAoiDialog(BaseDialog):

--- a/component/widget/custom_aoi_dialog.py
+++ b/component/widget/custom_aoi_dialog.py
@@ -28,9 +28,8 @@ def _outside_area(child: ee.Geometry, primary_fc: ee.FeatureCollection) -> ee.Nu
 
     Differences only against the primary features the child overlaps
     (``filterBounds``); ``primary_fc.geometry()`` would union the whole
-    collection and blow EE's 2M-edge limit on dense GAUL 2024 boundaries
-    (e.g. Indonesia, ~2.4M edges). Stays vector-exact, so the sub-m² tolerance
-    above is preserved.
+    collection and can exceed EE's 2M-edge limit on dense AOIs. Stays
+    vector-exact, so the sub-m² tolerance above is preserved.
     """
     nearby = primary_fc.filterBounds(child)
     return child.difference(nearby.geometry(), maxError=1).area()

--- a/component/widget/custom_aoi_dialog.py
+++ b/component/widget/custom_aoi_dialog.py
@@ -23,6 +23,19 @@ logger = logging.getLogger("SEPLAN")
 _CONTAINMENT_TOLERANCE_M2 = 1.0
 
 
+def _outside_area(child: ee.Geometry, primary_fc: ee.FeatureCollection) -> ee.Number:
+    """Area (m²) of ``child`` lying outside the primary AOI.
+
+    Differences only against the primary features the child overlaps
+    (``filterBounds``); ``primary_fc.geometry()`` would union the whole
+    collection and blow EE's 2M-edge limit on dense GAUL 2024 boundaries
+    (e.g. Indonesia, ~2.4M edges). Stays vector-exact, so the sub-m² tolerance
+    above is preserved.
+    """
+    nearby = primary_fc.filterBounds(child)
+    return child.difference(nearby.geometry(), maxError=1).area()
+
+
 class CustomAoiDialog(BaseDialog):
     feature: dict = None
     "feature collection of new geometry imported from ImportAoiDialog."
@@ -138,14 +151,13 @@ class CustomAoiDialog(BaseDialog):
     async def _validate_async(self):
         """Return the count of staged features that fall outside the primary AOI."""
         primary_fc = self.map_.aoi_model.feature_collection
-        primary_geom = primary_fc.geometry()
         gee_interface = self.map_.gee_interface
 
         outside_count = 0
         for feat in self._candidate_features:
             child = ee.Geometry(feat["geometry"])
             outside_area = await gee_interface.get_info_async(
-                child.difference(primary_geom, maxError=1).area()
+                _outside_area(child, primary_fc)
             )
             if outside_area is not None and outside_area > _CONTAINMENT_TOLERANCE_M2:
                 outside_count += 1

--- a/component/widget/custom_aoi_view.py
+++ b/component/widget/custom_aoi_view.py
@@ -149,8 +149,8 @@ class SeplanAoiView(AoiView):
         if fc is None:
             return
 
-        # Bounds → zoom. Per-feature bounding boxes avoid Collection.geometry's
-        # 2M-edge limit on large AOIs (see AoiModel.total_bounds_async).
+        # Bounds → zoom; per-feature bboxes avoid dissolving the AOI
+        # (see AoiModel.total_bounds_async).
         bounds = await self.model.total_bounds_async()
 
         self.map_.remove_layer("aoi", none_ok=True)
@@ -180,13 +180,9 @@ class SeplanAoiView(AoiView):
     def _update_aoi(self, *args):
         """Async-zoom submit for ADMIN/ASSET/SHAPE (DRAW uses ``_auto_submit_async``).
 
-        The build stays synchronous — identical to pysepal's ``_update_aoi`` —
-        so recipe-import timing and the wrapper's ``_loading`` guard (which
-        protects restored sub-AOIs) are unchanged. Only the EE-heavy extent +
-        zoom is deferred to the GEE loop, and it uses the async per-feature
-        ``total_bounds_async`` so dense GAUL 2024 boundaries (e.g. Indonesia,
-        ~2.4M edges) don't blow ``Collection.geometry``'s 2M-edge limit — which
-        is exactly what pysepal's sync ``total_bounds`` dissolve hit.
+        The build stays synchronous so recipe-import timing and the ``_loading``
+        guard that protects restored sub-AOIs are unchanged; only the EE-heavy
+        extent + zoom is deferred to the GEE loop, via ``total_bounds_async``.
         """
         gee_interface = getattr(self.model, "gee_interface", None)
         if not self.gee or gee_interface is None or self.map_ is None:

--- a/component/widget/custom_aoi_view.py
+++ b/component/widget/custom_aoi_view.py
@@ -149,13 +149,9 @@ class SeplanAoiView(AoiView):
         if fc is None:
             return
 
-        gee_interface = self.model.gee_interface
-
-        # Bounds → zoom (async getInfo on the GEE loop).
-        coords = await gee_interface.get_info_async(
-            fc.geometry().bounds().coordinates().get(0)
-        )
-        bounds = [coords[0][0], coords[0][1], coords[2][0], coords[2][1]]
+        # Bounds → zoom. Per-feature bounding boxes avoid Collection.geometry's
+        # 2M-edge limit on large AOIs (see AoiModel.total_bounds_async).
+        bounds = await self.model.total_bounds_async()
 
         self.map_.remove_layer("aoi", none_ok=True)
         self.map_.zoom_bounds(bounds)
@@ -180,6 +176,52 @@ class SeplanAoiView(AoiView):
         self.alert.add_msg(str(exc), type_="error")
         if self._app_model is not None:
             self._app_model.step_open = True
+
+    def _update_aoi(self, *args):
+        """Async-zoom submit for ADMIN/ASSET/SHAPE (DRAW uses ``_auto_submit_async``).
+
+        The build stays synchronous — identical to pysepal's ``_update_aoi`` —
+        so recipe-import timing and the wrapper's ``_loading`` guard (which
+        protects restored sub-AOIs) are unchanged. Only the EE-heavy extent +
+        zoom is deferred to the GEE loop, and it uses the async per-feature
+        ``total_bounds_async`` so dense GAUL 2024 boundaries (e.g. Indonesia,
+        ~2.4M edges) don't blow ``Collection.geometry``'s 2M-edge limit — which
+        is exactly what pysepal's sync ``total_bounds`` dissolve hit.
+        """
+        gee_interface = getattr(self.model, "gee_interface", None)
+        if not self.gee or gee_interface is None or self.map_ is None:
+            # non-gee / headless: keep pysepal's synchronous behaviour
+            return super()._update_aoi(*args)
+
+        self.model.set_object()
+        self.alert.add_msg(ms.aoi_sel.complete, "success")
+        if self.model.feature_collection is None:
+            return self
+
+        task = gee_interface.create_task(
+            func=self._zoom_async,
+            key="aoi_zoom",
+            on_error=self._on_auto_submit_error,
+        )
+        self._zoom_task = task  # hold a ref so the task isn't GC'd
+        task.start()
+        return self
+
+    async def _zoom_async(self):
+        """Zoom to the AOI extent and add its layer — off the kernel thread.
+
+        Uses ``total_bounds_async`` (per-feature bounding boxes) so the zoom box
+        for large countries never requires dissolving the whole collection.
+        """
+        bounds = await self.model.total_bounds_async()
+        self.map_.remove_layer("aoi", none_ok=True)
+        self.map_.zoom_bounds(bounds)
+
+        await self.map_.add_ee_layer_async(self.model.feature_collection, {}, "aoi")
+
+        if self.aoi_dc is not None:
+            self.aoi_dc.hide()
+        self.updated += 1
 
     def update_view(self, *args):
         """Update the view when the feature collection is updated."""

--- a/component/widget/custom_aoi_view.py
+++ b/component/widget/custom_aoi_view.py
@@ -80,6 +80,10 @@ class SeplanAoiView(AoiView):
             return
         if not getattr(self.seplan_aoi, "aoi_lmic_valid", True):
             return
+        # Partial-coverage / unverifiable AOIs are usable but carry a warning;
+        # keep the dialog open so the user actually reads it before continuing.
+        if getattr(self.seplan_aoi, "aoi_lmic_warning", False):
+            return
         self._app_model.step_open = False
 
     def _mirror_draw_event(self, target, action, geo_json):

--- a/component/widget/export_dialog.py
+++ b/component/widget/export_dialog.py
@@ -227,7 +227,7 @@ class ExportMapDialog(BaseDialog):
         # Mask to the AOI so the bbox region below exports nodata outside it (a
         # polygon region masks to its shape, a bbox region doesn't). clip(fc)
         # rasterises per feature, so it doesn't dissolve the AOI like
-        # aoi.geometry() would (which blows EE's 2M-edge limit on dense AOIs).
+        # aoi.geometry() would.
         ee_image = ee_image.clip(aoi)
 
         recipe_name = str(Path(self.recipe.recipe_session_path).stem)

--- a/component/widget/export_dialog.py
+++ b/component/widget/export_dialog.py
@@ -13,12 +13,13 @@ from component import parameter as cp
 from component import scripts as cs
 from component.message import cm
 from component.model.recipe import Recipe
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.scripts.gee import (
     apply_export_viz,
     get_ee_project_id,
     get_gee_recipe_folder_async,
 )
-from component.scripts.seplan import _aoi_bbox, asset_to_image, mask_image, quintiles
+from component.scripts.seplan import asset_to_image, mask_image, quintiles
 from component.scripts.ui_helpers import parse_export_name
 from component.widget.alert_state import Alert
 from component.widget.base_dialog import BaseDialog

--- a/component/widget/export_dialog.py
+++ b/component/widget/export_dialog.py
@@ -18,7 +18,7 @@ from component.scripts.gee import (
     get_ee_project_id,
     get_gee_recipe_folder_async,
 )
-from component.scripts.seplan import asset_to_image, mask_image, quintiles
+from component.scripts.seplan import _aoi_bbox, asset_to_image, mask_image, quintiles
 from component.scripts.ui_helpers import parse_export_name
 from component.widget.alert_state import Alert
 from component.widget.base_dialog import BaseDialog
@@ -223,6 +223,11 @@ class ExportMapDialog(BaseDialog):
         # The value from the w_asset is a tuple with (theme, id_)
         theme, id_ = self.w_asset.v_model
         ee_image = self.get_ee_image(theme, id_)
+        # Mask to the AOI so the bbox region below exports nodata outside it (a
+        # polygon region masks to its shape, a bbox region doesn't). clip(fc)
+        # rasterises per feature, so it doesn't dissolve the AOI like
+        # aoi.geometry() would (which blows EE's 2M-edge limit on dense AOIs).
+        ee_image = ee_image.clip(aoi)
 
         recipe_name = str(Path(self.recipe.recipe_session_path).stem)
 
@@ -232,7 +237,7 @@ class ExportMapDialog(BaseDialog):
         export_params = {
             "description": name,
             "scale": self.w_scale.v_model,
-            "region": aoi.geometry(),
+            "region": _aoi_bbox(aoi),
             "max_pixels": 1e13,
         }
 

--- a/component/widget/preview_map_dialog.py
+++ b/component/widget/preview_map_dialog.py
@@ -11,8 +11,8 @@ from sepal_ui.scripts.gee_task import GEETask
 
 from component import parameter as cp
 from component.message import cm
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.scripts.gee import create_layer
-from component.scripts.seplan import _aoi_bbox
 from component.widget.base_dialog import MapDialog
 from component.widget.buttons import TextBtn
 from component.widget.legend import Legend

--- a/component/widget/preview_map_dialog.py
+++ b/component/widget/preview_map_dialog.py
@@ -195,9 +195,8 @@ class PreviewMapDialog(MapDialog):
             geometry (ee.Geometry): the geometry of the AOI
 
         """
-        # clip image to the AOI, then reduce over its bbox: geometry=geometry
-        # would dissolve the AOI collection (Collection.geometry) and blow EE's
-        # 2M-edge limit on a dense GAUL 2024 boundary (e.g. Indonesia).
+        # clip image to the AOI, then reduce over its bbox: reducing over
+        # geometry=geometry would dissolve the AOI and can exceed the 2M-edge limit.
         ee_image = image.clip(geometry)
 
         # get minmax

--- a/component/widget/preview_map_dialog.py
+++ b/component/widget/preview_map_dialog.py
@@ -1,22 +1,19 @@
 """Custom dialog to display individual layers from questionnaire tile."""
 
 import asyncio
-from typing import Any, Literal, Optional, Union
+from typing import Literal
 
 import ee
-from component.scripts.gee import create_layer
 import sepal_ui.sepalwidgets as sw
-from sepal_ui.scripts.gee_task import GEETask
-from sepal_ui.frontend.resize_trigger import rt
-from sepal_ui.mapping import SepalMap
-import sepal_ui.scripts.decorator as sd
-from sepal_ui.mapping import InspectorControl
+from sepal_ui.mapping import InspectorControl, SepalMap
 from sepal_ui.scripts.gee_interface import GEEInterface
-
+from sepal_ui.scripts.gee_task import GEETask
 
 from component import parameter as cp
 from component.message import cm
-from component.widget.base_dialog import BaseDialog, MapDialog
+from component.scripts.gee import create_layer
+from component.scripts.seplan import _aoi_bbox
+from component.widget.base_dialog import MapDialog
 from component.widget.buttons import TextBtn
 from component.widget.legend import Legend
 
@@ -71,7 +68,6 @@ class PreviewMapDialog(MapDialog):
 
     def close_dialog(self, *_):
         """Closes the dialog."""
-
         for task in self._tasks.values():
             task.cancel()
 
@@ -86,10 +82,9 @@ class PreviewMapDialog(MapDialog):
 
     async def get_maps(self, aoi, ee_map, base_layer, vis_params, type_):
         """Returns the map and the legend."""
-
         coros = [
             self.gee_interface.get_map_id_async(aoi),
-            self.gee_interface.get_info_async(aoi.bounds().coordinates().get(0)),
+            self.gee_interface.get_info_async(_aoi_bbox(aoi).coordinates().get(0)),
             self.gee_interface.get_map_id_async(ee_map.clip(aoi), vis_params),
         ]
 
@@ -200,13 +195,15 @@ class PreviewMapDialog(MapDialog):
             geometry (ee.Geometry): the geometry of the AOI
 
         """
-        # clip image
+        # clip image to the AOI, then reduce over its bbox: geometry=geometry
+        # would dissolve the AOI collection (Collection.geometry) and blow EE's
+        # 2M-edge limit on a dense GAUL 2024 boundary (e.g. Indonesia).
         ee_image = image.clip(geometry)
 
         # get minmax
         min_max = ee_image.reduceRegion(
             reducer=ee.Reducer.minMax(),
-            geometry=geometry,
+            geometry=_aoi_bbox(geometry),
             scale=1,
             maxPixels=1e5,
             bestEffort=True,

--- a/component/widget/scenarios_dialog.py
+++ b/component/widget/scenarios_dialog.py
@@ -19,7 +19,7 @@ from component import parameter as cp
 from component.frontend.icons import icon
 from component.model.recipe import Recipe
 from component.scripts import gee
-from component.scripts.seplan import _aoi_bbox
+from component.scripts.aoi_geometry import _aoi_bbox
 from component.scripts.statistics import get_summary_statistics_async
 from component.scripts.validation import are_comparable, validate_scenarios_recipes
 from component.tile.dashboard_components import DashboardDialog

--- a/component/widget/scenarios_dialog.py
+++ b/component/widget/scenarios_dialog.py
@@ -1,33 +1,33 @@
 """UI component widget to compare different scenarios."""
 
 import asyncio
+import logging
 from copy import deepcopy
 from typing import List, Literal
 
 import ipyvuetify as v
 from ipyleaflet import SplitMapControl
-from traitlets import Dict as Dict, Int
-
-from component.tile.dashboard_components import DashboardDialog
-from sepal_ui.mapping import SepalMap
 from sepal_ui import sepalwidgets as sw
+from sepal_ui.mapping import SepalMap
 from sepal_ui.scripts.gee_interface import GEEInterface
 from sepal_ui.scripts.gee_task import GEETask
 from sepal_ui.scripts.sepal_client import SepalClient
+from traitlets import Dict as Dict
+from traitlets import Int
 
-import component.scripts.gee as gee
+from component import parameter as cp
 from component.frontend.icons import icon
 from component.model.recipe import Recipe
 from component.scripts import gee
+from component.scripts.seplan import _aoi_bbox
 from component.scripts.statistics import get_summary_statistics_async
 from component.scripts.validation import are_comparable, validate_scenarios_recipes
+from component.tile.dashboard_components import DashboardDialog
 from component.types import RecipeInfo, RecipePaths
 from component.widget.alert_state import Alert
 from component.widget.base_dialog import BaseDialog
 from component.widget.buttons import IconBtn
 from component.widget.custom_widgets import RecipeInput, TableIcon, TextBtn
-from component import parameter as cp
-import logging
 
 log = logging.getLogger("SEPLAN.scenarios_dialog")
 
@@ -118,7 +118,6 @@ class CompareScenariosDialog(BaseDialog):
 
     def close_dialog(self, *args):
         """Close the dialog and cancel any running tasks."""
-
         self.btn_compare_map._on_cancel()
         self.btn_compare_stat._on_cancel()
 
@@ -140,7 +139,6 @@ class CompareScenariosDialog(BaseDialog):
 
     async def _get_maps_with_recipes(self):
         """Get maps for comparison by first reading recipes."""
-
         map_ = self.map_
         map_.clean_map()
 
@@ -197,14 +195,12 @@ class CompareScenariosDialog(BaseDialog):
 
     def validate_scenarios(self):
         """Validate that all selected scenarios have the same AOI."""
-
         # First validate that all of them are valid
         validate_scenarios_recipes(self.scenario_inputs.recipe_paths)
         are_comparable(self.scenario_inputs.recipe_paths, self.sepal_session)
 
     async def read_recipes_async(self, folder=None) -> List[Recipe]:
         """Load the recipes from the recipe paths."""
-
         recipes = []
         self.validate_scenarios()
 
@@ -260,7 +256,7 @@ class CompareScenariosDialog(BaseDialog):
 
         # Get the bounds for centering the map (using the first recipe's AOI)
         bounds_task = self.gee_interface.get_info_async(
-            recipes[0].seplan_aoi.feature_collection.bounds().coordinates().get(0)
+            _aoi_bbox(recipes[0].seplan_aoi.feature_collection).coordinates().get(0)
         )
 
         # Combine all tasks
@@ -285,7 +281,6 @@ class CompareScenariosDialog(BaseDialog):
 
     def set_stats_content(self, overall_dashboard=None, theme_dashboard=None):
         """Set the content of the statistics dashboard."""
-
         self.overall_dashboard = overall_dashboard
         self.theme_dashboard = theme_dashboard
 
@@ -360,12 +355,10 @@ class ScenarioInputs(sw.Layout):
 
     def get_limit(self) -> int:
         """Count the number of inputs in the widget and return the number of inputs left."""
-
         return self.recipe_limit - len(self.recipe_paths)
 
     def add_input(self, *args):
         """Add a new input row to the widget."""
-
         if self.get_limit() > 0:
             self.tbody.children = self.tbody.children + [self.get_input_row()]
 
@@ -374,12 +367,10 @@ class ScenarioInputs(sw.Layout):
 
     def get_id_name(self, idx: int) -> str:
         """Get the name of the input based on the index."""
-
         return "recipe_path_" + str(idx)
 
     def remove_input_row(self, input_id: int):
         """Remove and dispose the a given file input."""
-
         row_to_remove = self.get_children(attr="id", value=input_id)
 
         if row_to_remove:
@@ -402,7 +393,6 @@ class ScenarioInputs(sw.Layout):
 
     def get_input_row(self, trashable=True, main_recipe: Recipe = None) -> v.Html:
         """Get a new file input."""
-
         row_id = self.get_id_name(self.idx)
 
         if trashable:
@@ -443,7 +433,6 @@ class ScenarioInputs(sw.Layout):
 
     def update_recipe_paths(self, change: dict):
         """Update the list of recipe paths."""
-
         recipe_id: str = change["owner"].attributes["id"]
         value_name = "path" if change["name"] == "v_model" else "valid"
         value = change["new"]

--- a/tests/test_aoi_bounds.py
+++ b/tests/test_aoi_bounds.py
@@ -1,12 +1,4 @@
-"""Regression test for async AOI extent retrieval.
-
-The admin/zoom path computed bounds via ``feature_collection.geometry()``
-(EE's ``Collection.geometry``), which dissolves the whole AOI and exceeds the
-2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges).
-``AoiModel.total_bounds_async`` derives the extent from per-feature bounding
-boxes via the async ``gee_interface`` instead, so the kernel thread never
-blocks and large countries don't raise.
-"""
+"""Regression: total_bounds_async must not dissolve a dense AOI."""
 
 import pygaul
 import pytest
@@ -18,8 +10,7 @@ from component.model.aoi_model import AoiModel
 async def test_total_bounds_async_handles_dense_aoi():
     """A dense admin boundary must not blow EE's 2M-edge dissolve limit."""
     model = AoiModel(folder="projects/test/assets")
-    # GAUL 2024 code for Indonesia (was 116 in GAUL 2015)
-    model.feature_collection = pygaul.AdmItems(admin="241")
+    model.feature_collection = pygaul.AdmItems(admin="241")  # GAUL 2024 Indonesia
 
     minx, miny, maxx, maxy = await model.total_bounds_async()
 

--- a/tests/test_aoi_bounds.py
+++ b/tests/test_aoi_bounds.py
@@ -1,0 +1,30 @@
+"""Regression test for async AOI extent retrieval.
+
+The admin/zoom path computed bounds via ``feature_collection.geometry()``
+(EE's ``Collection.geometry``), which dissolves the whole AOI and exceeds the
+2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges).
+``AoiModel.total_bounds_async`` derives the extent from per-feature bounding
+boxes via the async ``gee_interface`` instead, so the kernel thread never
+blocks and large countries don't raise.
+"""
+
+import pygaul
+import pytest
+
+from component.model.aoi_model import AoiModel
+
+
+@pytest.mark.asyncio
+async def test_total_bounds_async_handles_dense_aoi():
+    """A dense admin boundary must not blow EE's 2M-edge dissolve limit."""
+    model = AoiModel(folder="projects/test/assets")
+    # GAUL 2024 code for Indonesia (was 116 in GAUL 2015)
+    model.feature_collection = pygaul.AdmItems(admin="241")
+
+    minx, miny, maxx, maxy = await model.total_bounds_async()
+
+    # Indonesia spans roughly 95E-141E and 11S-6N
+    assert 94 < minx < 96
+    assert -12 < miny < -10
+    assert 140 < maxx < 142
+    assert 5 < maxy < 7

--- a/tests/test_custom_aoi_containment.py
+++ b/tests/test_custom_aoi_containment.py
@@ -1,0 +1,35 @@
+"""Regression test: sub-AOI containment must not dissolve a dense primary AOI.
+
+Validating a drawn sub-AOI computed ``child.difference(primary_fc.geometry())``,
+which dissolves the whole primary and exceeds EE's 2M-edge limit for dense
+GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges). ``_outside_area`` differences
+only against the primary features the child overlaps (``filterBounds``), so it
+stays vector-exact without ever materialising the union.
+"""
+
+import ee
+import pygaul
+import pytest
+
+from component.widget.custom_aoi_dialog import _outside_area
+
+# small polygon fully inside Java land; polygon crossing into the ocean
+_INSIDE = ee.Geometry.Polygon(
+    [[[110.0, -7.0], [110.1, -7.0], [110.1, -7.1], [110.0, -7.1]]]
+)
+_OCEAN = ee.Geometry.Polygon(
+    [[[110.0, -8.5], [110.3, -8.5], [110.3, -8.9], [110.0, -8.9]]]
+)
+
+
+def test_outside_area_avoids_dense_primary_dissolve():
+    primary = pygaul.AdmItems(name="Indonesia")
+
+    # the naive dissolve blows the 2M-edge limit on a dense primary ...
+    with pytest.raises(ee.EEException):
+        _INSIDE.difference(primary.geometry(), maxError=1).area().getInfo()
+
+    # ... but the fix does not: ~0 m² outside for a contained child,
+    # a large area for one that crosses into the ocean.
+    assert _outside_area(_INSIDE, primary).getInfo() < 1.0
+    assert _outside_area(_OCEAN, primary).getInfo() > 1e6

--- a/tests/test_custom_aoi_containment.py
+++ b/tests/test_custom_aoi_containment.py
@@ -1,11 +1,4 @@
-"""Regression test: sub-AOI containment must not dissolve a dense primary AOI.
-
-Validating a drawn sub-AOI computed ``child.difference(primary_fc.geometry())``,
-which dissolves the whole primary and exceeds EE's 2M-edge limit for dense
-GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges). ``_outside_area`` differences
-only against the primary features the child overlaps (``filterBounds``), so it
-stays vector-exact without ever materialising the union.
-"""
+"""Regression: sub-AOI containment must not dissolve a dense primary AOI."""
 
 import ee
 import pygaul

--- a/tests/test_custom_aoi_tile.py
+++ b/tests/test_custom_aoi_tile.py
@@ -21,3 +21,31 @@ def test_aoi_tile(empty_recipe):
     assert in_lmic is aoi_tile
     assert recipe.seplan_aoi.aoi_lmic_valid is False
     assert in_lmic.view.alert.children[0].children == [cm.aoi.not_lmic]
+
+
+def test_lmic_verdict_tiers(empty_recipe):
+    """The raster-path verdict grades land coverage into ok / warn / block."""
+    recipe = empty_recipe
+    aoi_tile = AoiView(map_=None, recipe=recipe)
+    seplan_aoi = recipe.seplan_aoi
+
+    # Majority LMIC (>= 0.5) → clean pass: usable, no warning. Dirty the state
+    # first to prove the verdict actively clears it.
+    seplan_aoi.aoi_lmic_valid = False
+    seplan_aoi.aoi_lmic_warning = True
+    aoi_tile._apply_lmic_verdict(0.99)
+    assert seplan_aoi.aoi_lmic_valid is True
+    assert seplan_aoi.aoi_lmic_warning is False
+
+    # Partial coverage (0 < frac < 0.5) — e.g. a coastal/archipelago box — is
+    # usable but warned (dialog stays open); message reports the rounded %.
+    aoi_tile._apply_lmic_verdict(0.2566)
+    assert seplan_aoi.aoi_lmic_valid is True
+    assert seplan_aoi.aoi_lmic_warning is True
+    assert aoi_tile.view.alert.children[0].children == [cm.aoi.partial_lmic.format(26)]
+
+    # No LMIC coverage at all → hard block with the out-of-scope message.
+    aoi_tile._apply_lmic_verdict(0.0)
+    assert seplan_aoi.aoi_lmic_valid is False
+    assert seplan_aoi.aoi_lmic_warning is False
+    assert aoi_tile.view.alert.children[0].children == [cm.aoi.not_lmic]

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -1,10 +1,4 @@
-"""Regression test: dashboard area stats must not dissolve a dense AOI.
-
-The per-AOI dashboard statistics reduced over ``geometry=aoi`` (the primary
-feature collection), which dissolves the whole AOI and exceeds EE's 2M-edge
-limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges). The fix
-clips the image to the AOI and reduces over its bounding box instead.
-"""
+"""Regression: dashboard area stats must not dissolve a dense AOI."""
 
 import ee
 import pygaul
@@ -14,8 +8,7 @@ from component.scripts import statistics
 
 def test_get_image_stats_handles_dense_aoi(monkeypatch):
     """Suitability-area stats over Indonesia must evaluate without dissolving."""
-    # The dissolve fails regardless of scale; coarsening the fixed stats scale
-    # only speeds up the post-fix reduction so the test stays fast.
+    # coarsen the fixed scale so the post-fix reduction stays fast
     monkeypatch.setattr(statistics, "STATS_SCALE_M", 10000)
 
     aoi = pygaul.AdmItems(name="Indonesia")

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -1,0 +1,24 @@
+"""Regression test: dashboard area stats must not dissolve a dense AOI.
+
+The per-AOI dashboard statistics reduced over ``geometry=aoi`` (the primary
+feature collection), which dissolves the whole AOI and exceeds EE's 2M-edge
+limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges). The fix
+clips the image to the AOI and reduces over its bounding box instead.
+"""
+
+import ee
+import pygaul
+
+from component.scripts import statistics
+
+
+def test_get_image_stats_handles_dense_aoi(monkeypatch):
+    """Suitability-area stats over Indonesia must evaluate without dissolving."""
+    # The dissolve fails regardless of scale; coarsening the fixed stats scale
+    # only speeds up the post-fix reduction so the test stays fast.
+    monkeypatch.setattr(statistics, "STATS_SCALE_M", 10000)
+
+    aoi = pygaul.AdmItems(name="Indonesia")
+    result = statistics.get_image_stats(ee.Image(3), ee.Image(1), aoi).getInfo()
+
+    assert result["total"] is not None

--- a/tests/test_get_limits.py
+++ b/tests/test_get_limits.py
@@ -1,0 +1,26 @@
+"""Regression test: constraint value limits must not dissolve a dense AOI.
+
+``get_limits_async`` reduced a constraint layer over ``geometry=aoi`` (the
+primary feature collection), which dissolves the AOI and exceeds EE's 2M-edge
+limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges). The fix
+clips the image to the AOI and reduces over its bounding box.
+"""
+
+import pygaul
+import pytest
+from sepal_ui.scripts.gee_interface import GEEInterface
+
+from component.scripts.gee import get_limits_async
+
+
+@pytest.mark.asyncio
+async def test_get_limits_async_handles_dense_aoi():
+    """Continuous-layer limits over Indonesia must evaluate without dissolving."""
+    aoi = pygaul.AdmItems(name="Indonesia")
+
+    # GTOPO30 (~1 km elevation) keeps the dense-AOI reduction fast; the dissolve
+    # in the old code failed regardless of the layer's resolution.
+    limits = await get_limits_async(GEEInterface(), "USGS/GTOPO30", "continuous", aoi)
+
+    assert len(limits) == 2
+    assert limits[0] < limits[1]

--- a/tests/test_get_limits.py
+++ b/tests/test_get_limits.py
@@ -1,10 +1,4 @@
-"""Regression test: constraint value limits must not dissolve a dense AOI.
-
-``get_limits_async`` reduced a constraint layer over ``geometry=aoi`` (the
-primary feature collection), which dissolves the AOI and exceeds EE's 2M-edge
-limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges). The fix
-clips the image to the AOI and reduces over its bounding box.
-"""
+"""Regression: get_limits_async must not dissolve a dense AOI."""
 
 import pygaul
 import pytest
@@ -18,8 +12,7 @@ async def test_get_limits_async_handles_dense_aoi():
     """Continuous-layer limits over Indonesia must evaluate without dissolving."""
     aoi = pygaul.AdmItems(name="Indonesia")
 
-    # GTOPO30 (~1 km elevation) keeps the dense-AOI reduction fast; the dissolve
-    # in the old code failed regardless of the layer's resolution.
+    # GTOPO30 (~1 km) keeps the dense-AOI reduction fast
     limits = await get_limits_async(GEEInterface(), "USGS/GTOPO30", "continuous", aoi)
 
     assert len(limits) == 2

--- a/tests/test_recipe_header_sync.py
+++ b/tests/test_recipe_header_sync.py
@@ -6,6 +6,8 @@ against the drift where the tile's new/save flows updated only the mirror,
 leaving the model (and therefore the header, exports and asset naming) stale.
 """
 
+import copy
+
 from component.model.recipe import RECIPE_SIGNATURE, Recipe
 from component.tile.recipe_tile import RecipeView
 from component.widget.alert_state import Alert
@@ -86,3 +88,46 @@ def test_header_inspector_uses_real_signature():
     header._on_view()
 
     assert header.inspector.data_dict["signature"] == RECIPE_SIGNATURE
+
+
+def test_inspector_preview_is_decoupled_from_live_model():
+    """An open preview must be a snapshot, not a live alias of the models.
+
+    ``to_dict`` builds its payload from the models' live ``_trait_values``
+    mappings, so without a copy the dict handed to the inspector keeps tracking
+    later edits. That silent mutation is what made the header preview show stale
+    data (and defeated the traitlets change-detection on re-view).
+    """
+    recipe = Recipe()
+    header = RecipeHeader(recipe=recipe, alert=Alert())
+
+    header._on_view()
+    shown = copy.deepcopy(header.inspector.data_dict)
+
+    # edit the recipe *after* the preview was taken
+    recipe.benefit_model.names = ["regression-sentinel"]
+
+    # the dict already handed to the inspector must not change underneath us
+    assert header.inspector.data_dict == shown
+
+
+def test_inspector_resyncs_on_reopen_after_edit():
+    """Re-viewing after an edit must change data_dict so the frontend re-syncs.
+
+    With live ``_trait_values`` aliasing, the second assignment compared equal
+    to the first (both tracked the same mutated objects), so the synced traitlet
+    emitted no change event and the Vue widget kept showing the stale snapshot.
+    """
+    recipe = Recipe()
+    header = RecipeHeader(recipe=recipe, alert=Alert())
+
+    header._on_view()
+
+    recipe.benefit_model.names = ["regression-sentinel"]
+
+    events = []
+    header.inspector.observe(lambda change: events.append(change["new"]), "data_dict")
+    header._on_view()
+
+    assert events, "data_dict did not change on re-view; inspector stays stale"
+    assert header.inspector.data_dict["benefits"]["names"] == ["regression-sentinel"]

--- a/tests/test_seplan_normalization.py
+++ b/tests/test_seplan_normalization.py
@@ -1,0 +1,31 @@
+"""Regression test: normalizing layers over a dense AOI must not dissolve it.
+
+The suitability-index normalization reduced layers over ``aoi.geometry()``
+(EE's ``Collection.geometry``), which dissolves the whole AOI and exceeds the
+2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges).
+The fix clips the image to the AOI and reduces over its bounding box instead —
+same pixels, no full-coastline union.
+"""
+
+import ee
+import pygaul
+
+from component.scripts.seplan import _percentile
+
+
+def test_percentile_normalization_handles_dense_aoi():
+    """_percentile over Indonesia must evaluate without the 2M-edge dissolve."""
+    aoi = pygaul.AdmItems(name="Indonesia")
+    image = ee.Image("USGS/SRTMGL1_003")
+
+    normalized = _percentile(image, aoi, scale=10000)
+
+    # Sampling the normalized output forces the internal reduceRegion (the
+    # global percentiles over the AOI) — the call that used to dissolve.
+    value = normalized.reduceRegion(
+        reducer=ee.Reducer.first(),
+        geometry=ee.Geometry.Point([107.6, -6.9]),
+        scale=1000,
+    ).getInfo()
+
+    assert value is not None

--- a/tests/test_seplan_normalization.py
+++ b/tests/test_seplan_normalization.py
@@ -1,11 +1,4 @@
-"""Regression test: normalizing layers over a dense AOI must not dissolve it.
-
-The suitability-index normalization reduced layers over ``aoi.geometry()``
-(EE's ``Collection.geometry``), which dissolves the whole AOI and exceeds the
-2M-edge limit for dense GAUL 2024 boundaries (e.g. Indonesia, ~2.4M edges).
-The fix clips the image to the AOI and reduces over its bounding box instead —
-same pixels, no full-coastline union.
-"""
+"""Regression: suitability normalization must not dissolve a dense AOI."""
 
 import ee
 import pygaul
@@ -20,8 +13,7 @@ def test_percentile_normalization_handles_dense_aoi():
 
     normalized = _percentile(image, aoi, scale=10000)
 
-    # Sampling the normalized output forces the internal reduceRegion (the
-    # global percentiles over the AOI) — the call that used to dissolve.
+    # sampling the output forces the internal reduceRegion (the call that dissolved)
     value = normalized.reduceRegion(
         reducer=ee.Reducer.first(),
         geometry=ee.Geometry.Point([107.6, -6.9]),


### PR DESCRIPTION
## Summary

Dense GAUL 2024 admin boundaries break Earth Engine's hard **2,000,000-edge** limit on `Collection.geometry`, the algorithm that `ee.FeatureCollection.geometry()` invokes: it **aggregates every feature into a single geometry**. For Indonesia's 4 disjoint island features (~600k edges each) that's one multipolygon of **≈ 2.45M edges** — over the cap. So after the GAUL 2015→2024 migration, selecting/using a large country threw `Collection.geometry: Geometry has too many edges` across most of the app.

(For disjoint features like islands there's nothing to topologically dissolve, so the combined geometry just carries the sum of all the features' edges — calling it a "union" is loose; the operative fact is that it builds one geometry from all of them.)

This PR stops building that combined geometry, using two patterns (note: `maxError` does **not** help — EE builds and edge-checks the full geometry *before* it simplifies):

- **Extents / zoom** → per-feature bounding boxes: `fc.map(f -> f.geometry().bounds()).geometry().bounds()`.
- **reduceRegion / reductions** → clip the image to the AOI and reduce over the per-feature bbox: `img.clip(aoi).reduceRegion(geometry=_aoi_bbox(aoi), ...)`. `clip(fc)` rasterises each feature separately, so it never builds the combined geometry.

## What's fixed (Indonesia now works end-to-end)

- **AOI load / zoom** — `AoiModel.total_bounds_async` (async, per-feature bbox); admin/draw submit.
- **Compute** — suitability normalization `quintiles` / `_percentile` / `_min_max` (`seplan.py`).
- **Dashboard stats** — area-by-class, means, sums, percent-cover (`statistics.py`) + dashboard map zoom.
- **Layer preview** — bounds + min/max (`preview_map_dialog`, `gee.get_layer_min_max`).
- **Scenario compare** — map zoom (`scenarios_dialog`).
- **Sub-AOI containment** — `filterBounds` + difference against only the overlapping primary features, instead of combining the whole primary (`custom_aoi_dialog`).
- **Constraint value limits** — `get_limits_async` (+ `bestEffort` so a continental AOI is ~3 s instead of ~2 min).
- **Export** — clip to AOI + bbox region.
- **LMIC check** — for large non-admin AOIs (`custom_aoi_tile`).

Also bundled on this branch:
- **Recipe inspector** — `Recipe.to_dict()` now returns a snapshot so the header preview isn't stale (pysepal's `export_data()` returns the live `_trait_values`).
- **LMIC coverage** graded into a tiered soft-gate.

## Verification

- The clip+bbox reduction is **statistically identical** to the old aggregate-and-reduce — confirmed by running the *actual* pre-change `statistics.py` against the new code on a small AOI: means/min/max identical; areas agree to within a single boundary pixel (~0.0001 % at 1 km, smaller at the production 100 m scale).
- The mechanism itself was verified against live EE, not assumed: per-feature bbox succeeds where `fc.geometry()` fails; `fc.geometry(maxError=N)` fails with the *same* edge count for every N (so the full geometry is built before simplification); `img.clip(fc)` succeeds (per-feature rasterisation, no combined geometry).
- Validated on Indonesia throughout (load, compute, dashboard, preview, sub-AOI, limits, LMIC). 5 new regression tests; full suite green.

## Notes

- The sync `get_limits` (gee.py) has the same bug but is dead/uncalled — left as-is.
