### PR TITLE
fix: AOI selection — zoom to the captured AOI + keep the validate button loading

### DIFF
--- a/component/model/aoi_model.py
+++ b/component/model/aoi_model.py
@@ -263,18 +263,21 @@ class AoiModel(AoiModel):
 
         return self
 
-    async def total_bounds_async(self):
+    async def total_bounds_async(self, fc=None):
         """Return the AOI extent ``[minx, miny, maxx, maxy]`` asynchronously.
 
-        Uses per-feature bounding boxes (see ``_aoi_bbox``) rather than the
-        dissolved collection geometry, which can exceed EE's 2M-edge limit for
-        dense AOIs. Fetched via ``get_info_async`` so the kernel never blocks.
+        Pass ``fc`` to compute from a captured feature collection instead of the
+        live ``feature_collection`` trait, which ``set_object`` transiently nulls
+        (via ``clear_output``) while rebuilding — a deferred zoom must use the AOI
+        it was scheduled with. Per-feature bounding boxes (see ``_aoi_bbox``) avoid
+        the dissolved-geometry edge limit; fetched via ``get_info_async``.
         """
-        if self.feature_collection is None:
+        fc = self.feature_collection if fc is None else fc
+        if fc is None:
             raise ValueError(ms.aoi_sel.exception.no_gdf)
 
         coords = await self.gee_interface.get_info_async(
-            _aoi_bbox(self.feature_collection).coordinates().get(0)
+            _aoi_bbox(fc).coordinates().get(0)
         )
         bounds = [coords[0][0], coords[0][1], coords[2][0], coords[2][1]]
         return [round(bound, 4) for bound in bounds]

--- a/component/widget/custom_aoi_view.py
+++ b/component/widget/custom_aoi_view.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from sepal_ui import mapping as sm
 from sepal_ui.aoi.aoi_view import AoiView
@@ -150,8 +151,9 @@ class SeplanAoiView(AoiView):
             return
 
         # Bounds → zoom; per-feature bboxes avoid dissolving the AOI
-        # (see AoiModel.total_bounds_async).
-        bounds = await self.model.total_bounds_async()
+        # (see AoiModel.total_bounds_async). Use the captured ``fc``, not the
+        # live trait, which set_object() can null mid-rebuild.
+        bounds = await self.model.total_bounds_async(fc)
 
         self.map_.remove_layer("aoi", none_ok=True)
         self.map_.zoom_bounds(bounds)
@@ -191,11 +193,15 @@ class SeplanAoiView(AoiView):
 
         self.model.set_object()
         self.alert.add_msg(ms.aoi_sel.complete, "success")
-        if self.model.feature_collection is None:
+        # Snapshot the freshly-built AOI: set_object() runs again during recipe
+        # import and transiently nulls feature_collection, so the deferred zoom
+        # must not re-read the live trait.
+        fc = self.model.feature_collection
+        if fc is None:
             return self
 
         task = gee_interface.create_task(
-            func=self._zoom_async,
+            func=partial(self._zoom_async, fc),
             key="aoi_zoom",
             on_error=self._on_auto_submit_error,
         )
@@ -203,17 +209,19 @@ class SeplanAoiView(AoiView):
         task.start()
         return self
 
-    async def _zoom_async(self):
-        """Zoom to the AOI extent and add its layer — off the kernel thread.
+    async def _zoom_async(self, fc):
+        """Zoom to the captured AOI extent and add its layer — off the kernel thread.
 
-        Uses ``total_bounds_async`` (per-feature bounding boxes) so the zoom box
-        for large countries never requires dissolving the whole collection.
+        Operates on the ``fc`` snapshot taken when the zoom was scheduled, not the
+        live ``feature_collection`` trait, which set_object() nulls mid-rebuild
+        during recipe import. Per-feature bounding boxes (see
+        ``total_bounds_async``) avoid dissolving the collection.
         """
-        bounds = await self.model.total_bounds_async()
+        bounds = await self.model.total_bounds_async(fc)
         self.map_.remove_layer("aoi", none_ok=True)
         self.map_.zoom_bounds(bounds)
 
-        await self.map_.add_ee_layer_async(self.model.feature_collection, {}, "aoi")
+        await self.map_.add_ee_layer_async(fc, {}, "aoi")
 
         if self.aoi_dc is not None:
             self.aoi_dc.hide()

--- a/component/widget/custom_aoi_view.py
+++ b/component/widget/custom_aoi_view.py
@@ -10,6 +10,17 @@ from component.model.aoi_model import SeplanAoi
 logger = logging.getLogger("SEPLAN")
 
 
+def _set_btn_loading(btn, loading: bool) -> None:
+    """Toggle a button's loading + disabled state across an async task.
+
+    Mirrors ``sw.Btn.toggle_loading`` (used by pysepal's synchronous
+    ``@loading_button``) so the validate button spins for the whole deferred
+    AOI build, not just the synchronous scheduling step.
+    """
+    btn.loading = loading
+    btn.disabled = loading
+
+
 class SeplanAoiView(AoiView):
     def __init__(self, model: SeplanAoi, app_model=None, **kwargs: dict):
         # ``self.model`` will be the inner ``AoiModel`` after super().__init__,
@@ -120,6 +131,8 @@ class SeplanAoiView(AoiView):
             self.btn.fire_event("click", None)
             return
 
+        # spin the validate button until _auto_submit_async finishes
+        _set_btn_loading(self.btn, True)
         task = gee_interface.create_task(
             func=self._auto_submit_async,
             key="aoi_auto_submit",
@@ -139,31 +152,34 @@ class SeplanAoiView(AoiView):
         if self.aoi_dc is None:
             return
 
-        self.model.geo_json = self.aoi_dc.to_json()
-        self.model.set_object()  # builds in-memory ee.FeatureCollection
+        try:
+            self.model.geo_json = self.aoi_dc.to_json()
+            self.model.set_object()  # builds in-memory ee.FeatureCollection
 
-        if self.map_ is None:
+            if self.map_ is None:
+                self.updated += 1
+                return
+
+            fc = self.model.feature_collection
+            if fc is None:
+                return
+
+            # Bounds → zoom; per-feature bboxes avoid dissolving the AOI
+            # (see AoiModel.total_bounds_async). Use the captured ``fc``, not the
+            # live trait, which set_object() can null mid-rebuild.
+            bounds = await self.model.total_bounds_async(fc)
+
+            self.map_.remove_layer("aoi", none_ok=True)
+            self.map_.zoom_bounds(bounds)
+
+            # add_ee_layer_async resolves the slow getMapId off the kernel thread.
+            await self.map_.add_ee_layer_async(fc, {}, "aoi")
+
+            self.aoi_dc.hide()
+            self.alert.add_msg(ms.aoi_sel.complete, "success")
             self.updated += 1
-            return
-
-        fc = self.model.feature_collection
-        if fc is None:
-            return
-
-        # Bounds → zoom; per-feature bboxes avoid dissolving the AOI
-        # (see AoiModel.total_bounds_async). Use the captured ``fc``, not the
-        # live trait, which set_object() can null mid-rebuild.
-        bounds = await self.model.total_bounds_async(fc)
-
-        self.map_.remove_layer("aoi", none_ok=True)
-        self.map_.zoom_bounds(bounds)
-
-        # add_ee_layer_async resolves the slow getMapId off the kernel thread.
-        await self.map_.add_ee_layer_async(fc, {}, "aoi")
-
-        self.aoi_dc.hide()
-        self.alert.add_msg(ms.aoi_sel.complete, "success")
-        self.updated += 1
+        finally:
+            _set_btn_loading(self.btn, False)
 
     def _on_auto_submit_error(self, exc: Exception):
         """Surface auto-submit failures via the AoiView alert area.
@@ -178,6 +194,8 @@ class SeplanAoiView(AoiView):
         self.alert.add_msg(str(exc), type_="error")
         if self._app_model is not None:
             self._app_model.step_open = True
+        # never leave the button stuck spinning if a task dies
+        _set_btn_loading(self.btn, False)
 
     def _update_aoi(self, *args):
         """Async-zoom submit for ADMIN/ASSET/SHAPE (DRAW uses ``_auto_submit_async``).
@@ -200,6 +218,8 @@ class SeplanAoiView(AoiView):
         if fc is None:
             return self
 
+        # spin the validate button until the deferred zoom finishes
+        _set_btn_loading(self.btn, True)
         task = gee_interface.create_task(
             func=partial(self._zoom_async, fc),
             key="aoi_zoom",
@@ -217,15 +237,18 @@ class SeplanAoiView(AoiView):
         during recipe import. Per-feature bounding boxes (see
         ``total_bounds_async``) avoid dissolving the collection.
         """
-        bounds = await self.model.total_bounds_async(fc)
-        self.map_.remove_layer("aoi", none_ok=True)
-        self.map_.zoom_bounds(bounds)
+        try:
+            bounds = await self.model.total_bounds_async(fc)
+            self.map_.remove_layer("aoi", none_ok=True)
+            self.map_.zoom_bounds(bounds)
 
-        await self.map_.add_ee_layer_async(fc, {}, "aoi")
+            await self.map_.add_ee_layer_async(fc, {}, "aoi")
 
-        if self.aoi_dc is not None:
-            self.aoi_dc.hide()
-        self.updated += 1
+            if self.aoi_dc is not None:
+                self.aoi_dc.hide()
+            self.updated += 1
+        finally:
+            _set_btn_loading(self.btn, False)
 
     def update_view(self, *args):
         """Update the view when the feature collection is updated."""

--- a/tests/test_aoi_zoom_snapshot.py
+++ b/tests/test_aoi_zoom_snapshot.py
@@ -1,0 +1,90 @@
+"""Regression: a scheduled AOI zoom must use the captured AOI, not the live trait.
+
+During recipe import ``set_object()`` runs several times, and each call starts
+with ``clear_output()`` which nulls ``feature_collection`` before rebuilding it.
+The zoom is deferred to the GEE thread, so if it re-reads the live trait it can
+observe that ``None`` window and raise "You must set the gdf before interacting
+with it". The zoom must instead use the AOI snapshot taken when it was scheduled.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from component.model.recipe import Recipe
+from component.scripts import validation
+from component.widget.custom_aoi_view import SeplanAoiView
+
+_RECIPES = Path(__file__).parent / "data/recipes"
+
+
+def _loaded_model(name: str):
+    """Load a real recipe fixture and build its primary AOI feature collection."""
+    recipe = Recipe()
+    result = recipe.load(_RECIPES / name)
+    if isinstance(result, validation.ValidationResult):
+        sanitized = validation.sanitize_recipe_data(result.raw_data, result)
+        recipe.load_sanitized(sanitized, result.recipe_path)
+    model = recipe.seplan_aoi.aoi_model
+    model.set_object()
+    return model
+
+
+class _FakeMap:
+    """Minimal ``map_`` stand-in that records the zoom call."""
+
+    def __init__(self):
+        self.zoomed = None
+
+    def remove_layer(self, name, none_ok=False):
+        pass
+
+    def zoom_bounds(self, bounds):
+        self.zoomed = bounds
+
+    async def add_ee_layer_async(self, fc, vis, name):
+        pass
+
+
+class _StubView:
+    """Stand-in for SeplanAoiView holding only what ``_zoom_async`` touches."""
+
+    aoi_dc = None
+
+    def __init__(self, model, map_):
+        self.model = model
+        self.map_ = map_
+        self.updated = 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("recipe_name", ["test_recipe.json", "antioquia_1.json"])
+async def test_total_bounds_async_uses_snapshot_over_live_trait(recipe_name):
+    """total_bounds_async must compute from a passed AOI, not the live trait."""
+    model = _loaded_model(recipe_name)
+    fc = model.feature_collection
+    assert fc is not None
+
+    # clear_output() inside a concurrent set_object() nulls the live trait
+    model.feature_collection = None
+
+    bounds = await model.total_bounds_async(fc)
+
+    assert len(bounds) == 4
+    assert bounds[0] < bounds[2] and bounds[1] < bounds[3]
+
+
+@pytest.mark.asyncio
+async def test_zoom_async_uses_snapshot_when_feature_collection_cleared():
+    """_zoom_async must zoom to the captured AOI even when the live trait is None."""
+    model = _loaded_model("test_recipe.json")
+    fc = model.feature_collection
+    assert fc is not None
+
+    model.feature_collection = None  # the clear_output() window
+
+    fake_map = _FakeMap()
+    await SeplanAoiView._zoom_async(_StubView(model, fake_map), fc)
+
+    assert fake_map.zoomed is not None
+    assert len(fake_map.zoomed) == 4

--- a/tests/test_aoi_zoom_snapshot.py
+++ b/tests/test_aoi_zoom_snapshot.py
@@ -7,6 +7,7 @@ observe that ``None`` window and raise "You must set the gdf before interacting
 with it". The zoom must instead use the AOI snapshot taken when it was scheduled.
 """
 
+import types
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,14 @@ class _FakeMap:
         pass
 
 
+class _FakeBtn:
+    """Records the loading/disabled state pysepal's loading button toggles."""
+
+    def __init__(self):
+        self.loading = False
+        self.disabled = False
+
+
 class _StubView:
     """Stand-in for SeplanAoiView holding only what ``_zoom_async`` touches."""
 
@@ -55,6 +64,7 @@ class _StubView:
         self.model = model
         self.map_ = map_
         self.updated = 0
+        self.btn = _FakeBtn()
 
 
 @pytest.mark.asyncio
@@ -88,3 +98,48 @@ async def test_zoom_async_uses_snapshot_when_feature_collection_cleared():
 
     assert fake_map.zoomed is not None
     assert len(fake_map.zoomed) == 4
+
+
+@pytest.mark.asyncio
+async def test_update_aoi_holds_button_loading_until_zoom_completes():
+    """The validate button stays loading from schedule until the async zoom ends."""
+    captured = {}
+
+    class _Gee:
+        def create_task(self, func, key=None, on_error=None):
+            captured["func"] = func
+            return types.SimpleNamespace(start=lambda: None)
+
+    sentinel_fc = object()
+
+    class _Model:
+        gee_interface = _Gee()
+        feature_collection = sentinel_fc
+
+        def set_object(self):
+            pass
+
+        async def total_bounds_async(self, fc):
+            assert fc is sentinel_fc
+            return [0.0, 0.0, 1.0, 1.0]
+
+    view = SeplanAoiView.__new__(SeplanAoiView)  # skip the UI-heavy __init__
+    view.gee = True
+    view.map_ = _FakeMap()
+    view.model = _Model()
+    view.alert = types.SimpleNamespace(add_msg=lambda *a, **k: None)
+    view.btn = _FakeBtn()
+    view.aoi_dc = None
+    view.updated = 0
+    view._app_model = None
+
+    view._update_aoi()
+    # spinner shown while the background task is still pending
+    assert view.btn.loading is True
+    assert view.btn.disabled is True
+
+    await captured["func"]()  # run the deferred _zoom_async(fc)
+    # cleared once the AOI is actually loaded
+    assert view.btn.loading is False
+    assert view.btn.disabled is False
+    assert view.map_.zoomed == [0.0, 0.0, 1.0, 1.0]


### PR DESCRIPTION
## Summary

Two regressions from the async AOI flow (#270), both surfaced when loading real recipes.

### 1. Recipe load crashed the AOI zoom (`cef68cb`)

`_zoom_async`/`_auto_submit_async` run on the GEE thread and re-read `model.feature_collection`, which `set_object() → clear_output()` transiently nulls while rebuilding. During recipe import `set_object()` fires several times, so the deferred zoom could read `None` and raise *"You must set the gdf before interacting with it"*. The AOI is now snapshotted when the zoom is scheduled and threaded through `total_bounds_async(fc)`, so the zoom never depends on the live, mutating trait.

### 2. Validate button stopped showing a loading spinner (`0bb4a0a`)

pysepal's `@loading_button` only spans the synchronous `_update_aoi`; once the build moved to a background task the spinner cleared immediately after scheduling. The button now holds `loading`/`disabled` from schedule until `_zoom_async`/`_auto_submit_async` finish (and on error), so it spins for the whole deferred selection. The headless/`gee=False` path still uses the decorated `super()._update_aoi` unchanged.

## Tests

New `tests/test_aoi_zoom_snapshot.py`:
- loads **real recipes** (Risaralda ADMIN1, Antioquia ADMIN2), snapshots the AOI, nulls the live trait (exactly what `clear_output()` does mid-rebuild), and asserts both the model helper and the real `_zoom_async` still zoom;
- asserts the validate button holds `loading`/`disabled` from schedule until the deferred zoom completes.

Both were confirmed RED before the fix. Full suite **100 passed**.
