### PR TITLE
perf(docker): poll healthcheck every 20s instead of 1s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,11 @@ services:
       LOCAL_SEPAL_PASSWORD: "${LOCAL_SEPAL_PASSWORD:-}"
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "8765"]
-      timeout: 60s
-      interval: 1s
-      retries: 60
+      start_period: 60s
+      start_interval: 1s
+      interval: 20s
+      timeout: 5s
+      retries: 3
     networks:
       - sepal
     restart: always


### PR DESCRIPTION
The healthcheck ran `nc` every 1s, which is ~90% of the container's idle CPU (3-4% on a t3.small). Bump to 20s to match app-launcher; `start_period`/`start_interval` keep startup detection fast.